### PR TITLE
feat(b7-1-schema): ai-native-rag/1.0.0 candidate scaffold schema (B.7.1)

### DIFF
--- a/.forge/_memory/b7-ai-native-rag-exploration.md
+++ b/.forge/_memory/b7-ai-native-rag-exploration.md
@@ -1,0 +1,101 @@
+# Exploration — `b7-ai-native-rag` (T7)
+
+> **Type** : research note (output `/forge:explore`, 2026-06-11)
+> **Statut** : RATIFIÉE 2026-06-11 — 3 décisions arbitrées par le mainteneur (cf. §4)
+> **Servira d'input à** : suite de sous-changes B.7.x (cf. §6 ci-dessous)
+> **Source contexte** : `docs/new-archetypes-plan.md` §6.2 (B.7), §11 (T7), §0.11 ;
+>   ARCHITECTURE-TARGET §10 (compliance T1/T2/T3) ; Constitution v2.0.0.
+> **Décision amont** : maintainer 2026-06-11 — T7 démarre par B.7 (pas B.6),
+>   car B.7 réutilise le substrat 2.0.0 déjà livré par B.8 (moins de net-new infra).
+
+---
+
+## 1. Taxonomie déjà câblée (acquis B.8)
+
+`archetype.schema.json` enum **contient déjà** `ai-native-rag` :
+
+> "AI-first archetype — pgvector 0.8 + LLM gateway (Mistral-EU / vLLM) + MCP
+> servers + Qwik streaming UI."
+
+⇒ B.7.1 ne touche **pas** l'enum. Il crée `.forge/schemas/ai-native-rag/1.0.0.yaml`.
+
+Base `ai-first/schema.yaml` (v1.0.0) existe et est riche en process :
+- phase `ai_brainstorm` AVANT proposal (Oracle → `ai-capability-map.md` +
+  `agent-architecture.md` + `risk-matrix.md`), **gate `fallback_strategy_defined`** ;
+- `ai_fallback_required: true` (toute feature IA doit avoir un fallback non-IA) ;
+- `pii_handling: explicit_consent_required` ; `token_budget_documented: true` ;
+- `non_determinism_testing: snapshot + property_based`.
+
+⇒ B.7.1 = `extends: ai-first` + ajout phases `embeddings-pipeline` (avant design)
+et `prompt-audit` (gate) per §6.2 B.7.1. La discipline AI-First est héritée, pas
+réinventée.
+
+## 2. Verify-then-pin — dépendances externes risquées (Context7, 2026-06-11)
+
+| Composant | Signal Context7 | Verdict faisabilité | Pin |
+|---|---|---|---|
+| **MCP Rust SDK `rmcp`** | `/modelcontextprotocol/rust-sdk`, High rep, 144 snippets. README live épingle `rmcp = { version = "0.16.0", features = ["server"] }`. Index Context7 snapshot = `v0_5_0` → **DRIFT de version**. Transport HTTP axum-natif `StreamableHttpService` + stdio ; macros `#[tool]`/`#[tool_router]` ; support OAuth (`AuthClient`). | 🟢 GREEN — SDK officiel, axum-natif (flagship déjà axum), OIDC-ready. | ⛔ **NE PAS figer ici.** verify-then-pin LIVE à B.7.2/standards (0.16.0 vs 0.5.0 à confirmer `cargo add`). |
+| **pgvector (extension)** | `/pgvector/pgvector`, High rep. Latest **0.8.2 (2026-02-25)**. HNSW cosine `vector_cosine_ops` confirmé ; PG18 supporté ; v0.9 **n'existe pas**. | 🟢 GREEN — déjà livré flagship B.8.5 (`pgvector/pgvector:0.8.2-pg17`). | Réutilise pin B.8.5. |
+| **pgvector crate (Rust)** | Côté Rust = crate `pgvector` + feature `sqlx`. Version crate non confirmée cette session. | 🟡 À vérifier | verify-then-pin LIVE B.7.2. |
+| **LLM gateway client** | Mistral-Scaleway / vLLM (OpenAI-compatible HTTP). Pas de lib figée. | 🟡 Décision A (cf. §4) | post-arbitrage. |
+| **Qwik streaming** | SSE / WebTransport — déjà livré B.8.9 (Qwik City). | 🟢 réutilise B.8.9 | — |
+
+> ⚠️ Leçon coroot/Q-004 institutionnalisée : aucun pin de version n'est figé
+> depuis une note d'exploration. Tous les pins ci-dessus sont des *candidats* à
+> confirmer LIVE (`cargo add` / `docker manifest inspect` / pub.dev) au moment
+> de l'implémentation, attrapés par les fixtures L2 du harness.
+
+## 3. Leverage B.8 — ce qui est DÉJÀ là (substrat 2.0.0)
+
+| Brique B.7 | Source déjà livrée | Reste à faire |
+|---|---|---|
+| Postgres + pgvector HNSW | B.8.5 (`pgvector:0.8.2-pg17`) | indexes HNSW + crate Rust |
+| Orchestration Temporal (Rust) | B8O (`temporalio-sdk 0.4.0`, DBOS annulé Rust) | workers RAG (activity-only, SDK pré-alpha) |
+| Qwik web surface | B.8.9 (Qwik City + Connect-ES v2) | streaming SSE/WebTransport |
+| Identité OIDC | B.8.7 Zitadel + B.8.12 Envoy SecurityPolicy JWT | MCP OAuth → même provider |
+| Transport Connect | B.8.6 (connectrpc 0.6.x) | endpoints RAG |
+| OTel app SDK | `t5-otel-app` (Rust + Flutter) | spans embeddings/LLM/prompt-audit |
+| Compliance bundle | I.5/I.6 (forward-stable AI-Act/DORA) | artefacts Themis K.5 |
+
+⇒ B.7 est essentiellement net-new sur **3 couches** : LLM gateway, MCP servers,
+pipeline RAG (embeddings + retrieval + re-ranking). Le reste est partagé.
+
+## 4. Décisions arbitrées (mainteneur, 2026-06-11)
+
+- **A — LLM gateway → ✅ thin proxy Rust axum IN-REPO.** Pas de gateway externe.
+  OpenAI-compatible vers Mistral-Scaleway / vLLM ; tier-aware natif (refus
+  OpenAI/Vertex/Bedrock à T3 per B.7.9 + J.8.c + Demeter K.3). Aligne le pattern
+  "zero new external dep" de J.8/K.3. → dimensionne `llm-gateway.md` (B.7.3) +
+  scaffolder (B.7.2).
+
+- **B — Séquencement → ✅ chaîne incrémentale (grain B.8.x).** 9 changes atomiques
+  reviewables/revertables (cf. §5), pas de monolithe B.7.2.
+
+- **C — Agent Pythia (K.2) → ✅ change dédié `b7-pythia`** (patron `k3-demeter`).
+
+- Différées en design.md (n'empêchent pas d'ouvrir B.7.1) :
+  - D — embeddings provider (Mistral-EU vs local Candle/fastembed ; T3 ⇒ self-host).
+  - E — MCP transport des stubs `db`/`file`/`search` (stdio subprocess vs HTTP axum).
+
+## 5. Séquence de changes proposée (post-arbitrage)
+
+1. `b7-1-schema` — `ai-native-rag/1.0.0.yaml` extends `ai-first` + phases
+   `embeddings-pipeline` & `prompt-audit`. Effort `S`. (patron `b8-3-schema-candidate`)
+2. `b7-standards` — `rag-patterns.md` + `llm-gateway.md` + `mcp-servers.md`. `M`.
+3. `b7-2-scaffolder` — backbone Rust (axum + Temporal + pgvector + gateway + MCP stubs)
+   + Qwik streaming. `XL` (ou éclaté selon décision B).
+4. `b7-pythia` — agent K.2 (patron `k3-demeter`). `M`.
+5. `b7-9-janus-ai` — B.7.9 + **J.8.c** (refus Vertex/Bedrock ; T3 ⇒ Mistral-EU/vLLM). `S`.
+6. `b7-5-ai-act` — B.7.5 + B.7.8, débloque Themis K.5 + `.forge/compliance/{ai-act,dora}/`. `M`.
+7. `b7-10-streaming` — Qwik SSE/WebTransport. `M`.
+8. `b7-7-example` — `examples/forge-rag-example/` (3 demos). `L`.
+9. `b7-6-harness` — `b7.test.sh` ≥35 + snapshot tarball. `M`.
+
+Dépendances dures : 1→2→3, puis 4–9 largement parallélisables.
+
+## 6. Mise à jour du registre de risques (§12)
+
+- « MCP encore en évolution » → **dégrader** : SDK Rust officiel mûr, axum-natif,
+  OAuth. Risque résiduel = churn d'API entre 0.5↔0.16 (mitigé verify-then-pin).
+- « DBOS Go SDK » → **caduc pour B.7** : DBOS annulé Rust (B8O), Temporal natif.
+  Risque résiduel = `temporalio-sdk` pré-alpha → activity-only workers, pin exact.

--- a/.forge/changes/b7-1-schema/.forge.yaml
+++ b/.forge/changes/b7-1-schema/.forge.yaml
@@ -1,0 +1,16 @@
+name: b7-1-schema
+status: implemented
+created: 2026-06-11
+schema: default
+constitution_version: "2.0.0"
+parent_audit_items:
+  - B.7.1  # docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0.yaml (extends ai-first + embeddings-pipeline/prompt-audit phases)
+depends_on:
+  - B.8.3.b  # check_versioned_schema_siblings (validate-foundations.sh:385+) — the generic versioned-schema validator this file must satisfy ON LANDING
+  - B.8.14   # cli/src/domain/schema-version.ts selectScaffoldableVersion — candidate/scaffoldable:false ⇒ `forge init --archetype ai-native-rag` refuses (exit 3) until B.7 scaffolder lands
+timeline:
+  proposed: 2026-06-11
+  specified: 2026-06-11
+  designed: 2026-06-11
+  planned: 2026-06-11
+  implemented: 2026-06-11

--- a/.forge/changes/b7-1-schema/.forge.yaml
+++ b/.forge/changes/b7-1-schema/.forge.yaml
@@ -1,5 +1,5 @@
 name: b7-1-schema
-status: implemented
+status: archived
 created: 2026-06-11
 schema: default
 constitution_version: "2.0.0"
@@ -14,3 +14,4 @@ timeline:
   designed: 2026-06-11
   planned: 2026-06-11
   implemented: 2026-06-11
+  archived: 2026-06-11

--- a/.forge/changes/b7-1-schema/.forge.yaml
+++ b/.forge/changes/b7-1-schema/.forge.yaml
@@ -7,7 +7,7 @@ parent_audit_items:
   - B.7.1  # docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0.yaml (extends ai-first + embeddings-pipeline/prompt-audit phases)
 depends_on:
   - B.8.3.b  # check_versioned_schema_siblings (validate-foundations.sh:385+) — the generic versioned-schema validator this file must satisfy ON LANDING
-  - B.8.14   # cli/src/domain/schema-version.ts selectScaffoldableVersion — candidate/scaffoldable:false ⇒ `forge init --archetype ai-native-rag` refuses (exit 3) until B.7 scaffolder lands
+  - B.8.14   # cli/src/domain/schema-version.ts selectScaffoldableVersion — candidate/scaffoldable:false ⇒ no scaffoldable version. NB: init refuses with exit 2 (unknown archetype, dispatch-table gate init.ts:210) until B.7.2 registers ai-native-rag; exit 3 (selectScaffoldableVersion null) is the gate thereafter (Q-005)
 timeline:
   proposed: 2026-06-11
   specified: 2026-06-11

--- a/.forge/changes/b7-1-schema/design.md
+++ b/.forge/changes/b7-1-schema/design.md
@@ -1,0 +1,238 @@
+# Design: b7-1-schema
+
+<!-- Status: designed -->
+<!-- Schema: default -->
+<!-- Audit: B.7.1 (docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0 archetype scaffold schema) -->
+
+Resolves `open-questions.md` Q-001..Q-004 into ADRs. No library is pinned here
+(FR-B7-1-032; `rmcp`/pgvector-crate verify-then-pin deferred to B.7.2/B.7.3), so
+no Context7 lookup is required for this change — the grounding was done in the
+ratified exploration. This is a **propose+specify+design** artifact; the schema
+file + harness are authored at the implementation phase (after `/forge:plan`).
+
+## Architecture Decisions
+
+### ADR-B7-1-001 — AI-First phases are INLINED, not inherited via `extends`
+**Context**: §6.2 says the schema "extends `ai-first`". But `ai-first/schema.yaml`
+is a *workflow* schema; the file lives at the *archetype scaffold* path. **No
+scaffold-schema loader resolves `extends`**: `parseSchemaMeta`
+(schema-version.ts:30) reads only `version`/`stage`/`scaffoldable`;
+`check_versioned_schema_siblings` (validate-foundations.sh:455-457) reads `phases`
+**from the file itself**; `grep -rn extends cli/src .forge/scripts` returns only
+Dart-widget matches. An `extends: ai-first` would leave `phases` empty → validator
+KO `phases missing or empty`.
+**Decision**: materialise the `ai-first` phase list **inline** into `1.0.0.yaml`,
+extended with the two B.7.1 phases. Retain `extends: ai-first` as a **documentary
+provenance key only** (commented as non-load-bearing). Option (b) — building an
+`extends` resolver for scaffold schemas — is **rejected for B.7.1** (cross-cutting
+CLI + bash-validator change, far beyond an effort-S brick; candidate for a future
+G.* tooling brick).
+**Consequences**: self-contained, validates on landing, zero loader change. Cost =
+phase duplication vs `ai-first/schema.yaml` (drift risk) → mitigated by
+`b7-1.test.sh` asserting the AI-First phase set is present (NFR-B7-1-004).
+**Constitution Compliance**: Article IV (additive, no loader edit) + III.4 (the
+§6.2 conflation is recorded, not normalised) confirmed.
+
+### ADR-B7-1-002 — `candidate` + `scaffoldable: false`; promotion deferred to the B.7 scaffolder-flip
+**Context**: B.7.1 ships no templates; the archetype must not be scaffoldable yet.
+b8-3b enforces `candidate ⇒ scaffoldable: false`. `selectScaffoldableVersion`
+returns null when no version is stable+scaffoldable → `forge init` refuses (exit 3).
+**Decision**: `stage: candidate`, `scaffoldable: false`. Promotion to `stable` +
+`scaffoldable: true` happens in the **B.7 scaffolder-completion brick**, gated on a
+green `b7-6` harness proving a real scaffold (the B.8.14-C2 pattern). Tentative
+owner: the brick that ships `scaffold-plan-ai-native-rag.yaml` + the example +
+harness; its exact id is fixed when the B.7 chain is sequenced (recorded, not
+guessed).
+**Consequences**: `forge init --archetype ai-native-rag` refuses cleanly until the
+archetype actually produces a working tree; no broken scaffold can ship.
+**Constitution Compliance**: Article V (no premature advertise of an unproven
+archetype) confirmed.
+
+### ADR-B7-1-003 — components reference-only; LLM-gateway/MCP/RAG standards deferred to B.7.3
+**Context**: pgvector/Temporal/Zitadel/Connect/Qwik/observability standards exist;
+`llm-gateway`/`mcp-servers`/`rag-patterns` do not (they are B.7.3). Mirrors the
+B.8.3 Envoy-pin gap.
+**Decision**: declare the component SET by name; reference the **existing**
+standards by filename; mark the **three missing** ones `delivered_by: B.7.3` with
+no inline pin and no fabricated filename presented as existing. No verify-then-pin
+candidate (`rmcp`, pgvector crate) is committed in the schema.
+**Consequences**: single source of truth for pins stays in the standards; no drift;
+no fabrication.
+**Constitution Compliance**: Article III.4 (no fabrication) + Article IV confirmed.
+
+### ADR-B7-1-004 — layers = backend/frontend/infra; Qwik streaming under `frontend.surfaces`
+**Context**: the validator requires the backend/frontend/infra triple. The Qwik
+streaming UI is a public-web surface, not a Flutter app.
+**Decision**: model the triple with the Qwik streaming UI as a `frontend.surfaces`
+entry (mirroring `full-stack-monorepo/2.0.0.yaml` `frontend.surfaces.web-public`),
+**not** a new top-level layer. `primary_agent`: backend → **Vulcan**, infra →
+**Atlas**, frontend → **Hera** (consistent with the flagship 2.0.0, whose
+Qwik web-public surface sits under the Hera-owned frontend layer). A dedicated
+web/Qwik agent is out of scope (none exists in the roster; revisit if K.4 Iris-Web
+later owns web surfaces).
+**Consequences**: keeps the required-triple invariant intact; reuses the proven
+flagship surface shape; Janus arbitrates cross-surface changes via `cross_layer`.
+**Constitution Compliance**: Article IV + FR-B7-1-010/012 shape confirmed.
+
+## Component Design
+
+The deliverable is one declarative file. Its relationships:
+
+```mermaid
+graph TD
+  ENUM["archetype.schema.json enum<br/>(already lists ai-native-rag)"]
+  SCHEMA["ai-native-rag/1.0.0.yaml<br/>(THIS — candidate, scaffoldable:false)"]
+  VAL["validate-foundations.sh<br/>check_versioned_schema_siblings (b8-3b)"]
+  CLI["schema-version.ts<br/>selectScaffoldableVersion"]
+  STD_EXIST["persistence / orchestration / identity /<br/>transport / web-frontend / observability .yaml"]
+  STD_DEFER["llm-gateway / mcp-servers / rag-patterns<br/>(NOT YET — B.7.3)"]
+  HARNESS["b7-1.test.sh (impl)"]
+
+  SCHEMA -->|name==dir, version==file, layers⊇{be,fe,infra},<br/>candidate⇒scaffoldable:false, phases| VAL
+  SCHEMA -->|candidate/false ⇒ null ⇒ exit 3| CLI
+  SCHEMA -->|reference-only, no inline pin| STD_EXIST
+  SCHEMA -.->|delivered_by: B.7.3, gap recorded| STD_DEFER
+  SCHEMA -->|AI-First phase set asserted| HARNESS
+  ENUM -.->|taxonomy, untouched| SCHEMA
+```
+
+Target file skeleton (design blueprint — built at impl, values final at impl):
+
+```yaml
+# Forge Schema — ai-native-rag 1.0.0 (CANDIDATE)
+# <!-- Audit: B.7.1 (b7-1-schema) — AI-native RAG archetype scaffold schema -->
+# Stage: candidate, scaffoldable:false — no templates yet (B.7.2). Promotes to
+# stable+scaffoldable in the B.7 scaffolder-completion brick, gated on b7-6
+# harness (ADR-B7-1-002, B.8.14-C2 pattern). Additive: no existing archetype
+# affected. `extends: ai-first` below is DOCUMENTARY PROVENANCE ONLY — no loader
+# resolves it; the AI-First phases are materialised inline (ADR-B7-1-001).
+name: ai-native-rag
+version: "1.0.0"
+stage: candidate
+scaffoldable: false
+extends: ai-first            # documentary provenance only (non-load-bearing)
+description: >
+  AI-first RAG archetype: Rust backend (RAG pipeline + in-repo LLM gateway proxy +
+  MCP servers) + Qwik streaming UI + Postgres/pgvector + Temporal + Zitadel +
+  SigNoz/OBI/Coroot. TDD+BDD enforced; mandatory AI fallback (XI.5); PII-guarded
+  (XI.6); prompt-audit + token budget traced (IX.6). Not scaffoldable until B.7.2.
+tdd_enforced: true
+bdd_required_for_user_facing: true
+coverage_threshold: 80
+ai_fallback_required: true   # Article XI.5
+
+components:                  # reference-only (ADR-B7-1-003) — NO inline pins
+  - {name: pgvector,        role: persistence,    standard: persistence.yaml}
+  - {name: temporal,        role: orchestration,  standard: orchestration.yaml}  # §VIII.2 (rust default)
+  - {name: zitadel,         role: identity,       standard: identity.yaml}
+  - {name: connect-rpc,     role: transport,      standard: transport.yaml}
+  - {name: qwik-streaming,  role: web-public,     standard: web-frontend.yaml}
+  - {name: observability,   role: observability,  standard: observability.yaml}
+  - {name: llm-gateway,     role: ai-inference,   delivered_by: B.7.3}  # in-repo proxy; standard NOT YET
+  - {name: mcp-servers,     role: tooling,        delivered_by: B.7.3}  # rmcp; standard NOT YET
+  - {name: rag-pipeline,    role: retrieval,      delivered_by: B.7.3}  # rag-patterns; standard NOT YET
+
+layers:                      # required triple (ADR-B7-1-004)
+  - id: backend
+    path: backend/
+    fr_id_prefix: FR-BE-
+    primary_agent: Vulcan
+    standards_scope: [rust, all]
+  - id: frontend
+    path: frontend/
+    fr_id_prefix: FR-FE-
+    primary_agent: Hera
+    standards_scope: [flutter, all]
+    surfaces:
+      - {id: web-public, path: web-public/, stack: qwik, note: "Qwik streaming UI (SSE/WebTransport) — B.7.10"}
+  - id: infra
+    path: infra/
+    fr_id_prefix: FR-IN-
+    primary_agent: Atlas
+    standards_scope: [infra, all]
+
+fr_id_prefix_cross_layer: FR-GL-
+cross_layer:
+  agent: Janus
+  triggers: [{layers_count_ge: 2}]
+
+phases:                      # INLINED (ADR-B7-1-001) — ai-first materialised + 2 B.7.1 additions
+  - {id: ai_brainstorm, agent: Oracle, artifact: [ai-capability-map.md, agent-architecture.md, risk-matrix.md], gate: fallback_strategy_defined, next: proposal}
+  - {id: proposal, artifact: proposal.md, gate: constitution_compliance, next: specs}
+  - {id: specs, artifact: specs.md, agent: Clio, gate: anti_hallucination_check, next: embeddings-pipeline}
+  - {id: embeddings-pipeline, artifact: embeddings-pipeline.md, gate: pipeline_specified, next: features}   # B.7.1 addition (§6.2)
+  - {id: features, artifact: "features/*.feature", includes: [happy_path_with_ai, fallback_scenarios, error_scenarios], next: design}
+  - {id: design, artifact: design.md, agent: [Athena, Prometheus], gate: constitution_compliance, next: prompt-audit}
+  - {id: prompt-audit, artifact: prompt-audit.md, gate: prompt_audit_logging_defined, next: tasks}           # B.7.1 addition (§6.2), wires IX.6
+  - {id: tasks, artifact: tasks.md, gate: per_task_constitution_check, next: implementation}
+  - {id: implementation, protocol: tdd_cycle, agent: [Hera, Vulcan, Prometheus], next: review}
+  - {id: review, agent: [Nemesis, Tribune, Aegis, Prometheus], checks: [coverage, fallback_verified, pii_audit, token_budget], next: archive}
+  - {id: archive}
+
+ai_specifics:                # carried from ai-first (XI.5/XI.6, IX.6)
+  fallback_mandatory: true
+  pii_handling: explicit_consent_required
+  token_budget_documented: true
+  non_determinism_testing: {strategy: snapshot + property_based, acceptable_variance: defined_per_feature}
+```
+
+## Data Flow
+
+`forge init --archetype ai-native-rag` while only a candidate schema exists:
+
+```mermaid
+sequenceDiagram
+  participant U as user
+  participant CLI as forge init
+  participant SV as selectScaffoldableVersion
+  U->>CLI: forge init --archetype ai-native-rag
+  CLI->>SV: metas = [{1.0.0, candidate, scaffoldable:false}]
+  SV-->>CLI: null (no stable+scaffoldable)
+  CLI-->>U: REFUSE — exit 3 (not scaffoldable until B.7.2)
+```
+
+## Testing Strategy
+
+TDD order (Article I — RED before GREEN), at the implementation phase:
+1. **RED**: author `.forge/scripts/tests/b7-1.test.sh` asserting the schema's
+   AI-specific content (inlined phases incl. `ai_brainstorm`/`embeddings-pipeline`/
+   `prompt-audit`; `ai_specifics`; reference-only components; the three
+   `delivered_by: B.7.3` gaps). Run → **fails** (no schema file yet). Verify RED.
+2. **GREEN**: author `.forge/schemas/ai-native-rag/1.0.0.yaml` per the skeleton.
+   Run `b7-1.test.sh` → PASS; run `validate-foundations.sh` →
+   `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS. Verify GREEN.
+3. **REFACTOR**: tidy comments/anchors; re-run; confirm `verify.sh` +
+   `constitution-linter.sh` no regression; `forge init --archetype ai-native-rag`
+   → exit 3.
+- **Unit-level**: grep/structural assertions in `b7-1.test.sh` (L1, hermetic).
+- **Integration**: `validate-foundations.sh` versioned-sibling PASS (L1);
+  optional L2 `forge init` refusal exit-3 fixture.
+- **BDD**: not applicable — this change ships a config schema, not a user-facing
+  feature. (BDD for AI features arrives with B.7.2+ via the schema's own
+  `features` phase.)
+- Register `b7-1.test.sh` in `.github/workflows/forge-ci.yml`.
+
+## Standards Applied
+
+- **`global/open-questions.md`**: Q-001..Q-004 mechanised, resolved here.
+- **`global/source-document-pinning.md`** / Article III.4: §6.2 conflation +
+  missing standards recorded, not normalised; no library pin in this change.
+- **Component standards** (referenced, not edited): `persistence.yaml`,
+  `orchestration.yaml` (v1.2.0, rust→temporal), `identity.yaml`, `transport.yaml`,
+  `web-frontend.yaml` (B.8.9), `observability.yaml` (v2.1.0).
+- **Articles I/II/X**: TDD + (n/a BDD) + 80% coverage flags carried in the schema.
+- **Article XI.5/XI.6 + IX.6**: materialised by `ai_specifics` + the `prompt-audit`
+  phase + review checks (fallback_verified, pii_audit, token_budget).
+
+## Constitutional Compliance Gate
+
+- Article I (TDD): impl is test-first (`b7-1.test.sh` RED→GREEN). ✓ no violation.
+- Article VI (Flutter) / VII (Rust): no Flutter/Rust code in this change. ✓ N/A.
+- Article VIII (Infra): Envoy (§VIII.1) + Temporal (§VIII.2) referenced as-is, no
+  amendment. ✓
+- Article IV (delta): additive — no existing schema/standard/CLI edited. ✓
+- Article XI (AI-First): schema materialises XI.5/XI.6 + IX.6 into the archetype
+  process. ✓
+- Article III.4: no fabrication; deferred standards + verify-then-pin candidates
+  explicitly not committed. ✓
+**Gate result: PASS — no article violated.**

--- a/.forge/changes/b7-1-schema/design.md
+++ b/.forge/changes/b7-1-schema/design.md
@@ -36,7 +36,11 @@ phase duplication vs `ai-first/schema.yaml` (drift risk) → mitigated by
 ### ADR-B7-1-002 — `candidate` + `scaffoldable: false`; promotion deferred to the B.7 scaffolder-flip
 **Context**: B.7.1 ships no templates; the archetype must not be scaffoldable yet.
 b8-3b enforces `candidate ⇒ scaffoldable: false`. `selectScaffoldableVersion`
-returns null when no version is stable+scaffoldable → `forge init` refuses (exit 3).
+returns null when no version is stable+scaffoldable. Today `forge init` refuses
+this archetype with **exit 2** (unknown archetype — the `init.ts:210`
+dispatch-table gate fires before the schema layer); the null → **exit 3** path is
+reachable only once B.7.2 registers the archetype (Q-005). Either way: clean
+refusal, no scaffold.
 **Decision**: `stage: candidate`, `scaffoldable: false`. Promotion to `stable` +
 `scaffoldable: true` happens in the **B.7 scaffolder-completion brick**, gated on a
 green `b7-6` harness proving a real scaffold (the B.8.14-C2 pattern). Tentative
@@ -89,7 +93,7 @@ graph TD
   HARNESS["b7-1.test.sh (impl)"]
 
   SCHEMA -->|name==dir, version==file, layers⊇{be,fe,infra},<br/>candidate⇒scaffoldable:false, phases| VAL
-  SCHEMA -->|candidate/false ⇒ null ⇒ exit 3| CLI
+  SCHEMA -->|not dispatch-registered ⇒ exit 2 today;<br/>candidate/false ⇒ null ⇒ exit 3 once registered| CLI
   SCHEMA -->|reference-only, no inline pin| STD_EXIST
   SCHEMA -.->|delivered_by: B.7.3, gap recorded| STD_DEFER
   SCHEMA -->|AI-First phase set asserted| HARNESS
@@ -178,17 +182,28 @@ ai_specifics:                # carried from ai-first (XI.5/XI.6, IX.6)
 
 ## Data Flow
 
-`forge init --archetype ai-native-rag` while only a candidate schema exists:
+`forge init <name> --archetype ai-native-rag --org <rd>` while only a candidate
+schema exists. **Verified live (2026-06-11): the actual refusal is exit 2**
+("unknown archetype"), NOT exit 3 — because `init.ts:210-216` checks the
+dispatch-table FIRST and `ai-native-rag` is not registered in
+`.forge/scaffolding/dispatch-table.yml`. The `selectScaffoldableVersion`-null →
+exit-3 guard (`init.ts:232-238`) is DOWNSTREAM and only reached for a *registered*
+archetype. Both are clean refusals with no scaffold (NFR-B7-1-002). The exit-3
+path becomes the active gate only once B.7.2 registers `ai-native-rag` in the
+dispatch-table while the schema stays candidate/scaffoldable:false (open-questions
+Q-005).
 
 ```mermaid
 sequenceDiagram
   participant U as user
-  participant CLI as forge init
+  participant CLI as forge init (init.ts)
+  participant DT as dispatch-table.yml
   participant SV as selectScaffoldableVersion
-  U->>CLI: forge init --archetype ai-native-rag
-  CLI->>SV: metas = [{1.0.0, candidate, scaffoldable:false}]
-  SV-->>CLI: null (no stable+scaffoldable)
-  CLI-->>U: REFUSE — exit 3 (not scaffoldable until B.7.2)
+  U->>CLI: forge init testproj --archetype ai-native-rag --org com.example.test
+  CLI->>DT: archetypes['ai-native-rag'] ? (init.ts:210)
+  DT-->>CLI: undefined (not registered — B.7.2 will add it)
+  CLI-->>U: REFUSE — exit 2 "unknown archetype" (current gate)
+  Note over CLI,SV: downstream / FUTURE (once registered by B.7.2):<br/>metas=[{1.0.0,candidate,scaffoldable:false}] ⇒ SV null ⇒ exit 3
 ```
 
 ## Testing Strategy
@@ -202,11 +217,11 @@ TDD order (Article I — RED before GREEN), at the implementation phase:
    Run `b7-1.test.sh` → PASS; run `validate-foundations.sh` →
    `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS. Verify GREEN.
 3. **REFACTOR**: tidy comments/anchors; re-run; confirm `verify.sh` +
-   `constitution-linter.sh` no regression; `forge init --archetype ai-native-rag`
-   → exit 3.
+   `constitution-linter.sh` no regression; `forge init <name> --archetype
+   ai-native-rag --org <rd>` → exit 2 (clean refusal, dispatch-table-gated).
 - **Unit-level**: grep/structural assertions in `b7-1.test.sh` (L1, hermetic).
 - **Integration**: `validate-foundations.sh` versioned-sibling PASS (L1);
-  optional L2 `forge init` refusal exit-3 fixture.
+  L2 `forge init` clean-refusal fixture (exit 2 today; opt-in `FORGE_B7_1_LIVE`).
 - **BDD**: not applicable — this change ships a config schema, not a user-facing
   feature. (BDD for AI features arrives with B.7.2+ via the schema's own
   `features` phase.)

--- a/.forge/changes/b7-1-schema/open-questions.md
+++ b/.forge/changes/b7-1-schema/open-questions.md
@@ -12,7 +12,8 @@ INDEPENDENT reviewer + the maintainer, not self-approved here.
 - **Q-003** resolved at /forge:design 2026-06-11 → option (a) reference-only + delivered_by:B.7.3. ADR-B7-1-003 finalized.
 - **Q-004** resolved at /forge:design 2026-06-11 → option (a) Qwik under frontend.surfaces; primary_agent be:Vulcan/fe:Hera/infra:Atlas. ADR-B7-1-004 finalized.
 - **Q-005** raised by the independent reviewer at /forge:review 2026-06-11 (HIGH finding) → option (a): exit 2 accepted as the B.7.1 clean refusal, dispatch-table registration + exit-3 flip deferred to B.7.2. Test + docs corrected; re-verified live 19/19.
-- NOTE: Q-001..Q-004 resolutions authored at design; Q-005 raised + resolved at the independent review pass (Article V — reviewer was a separate context, not self-approval). Maintainer ratification of all five pending final sign-off.
+- NOTE: Q-001..Q-004 resolutions authored at design; Q-005 raised + resolved at the independent review pass (Article V — reviewer was a separate context, not self-approval). Independent code-reviewer verdict: **APPROVE** (2026-06-11, after one fix iteration on the HIGH exit-code finding).
+- **MAINTAINER RATIFICATION 2026-06-11**: BDFL ratified ADR-B7-1-001..004 + the Q-005 resolution (exit-2 dispatch-gate now, dispatch-table registration + exit-3 flip deferred to B.7.2). All five decisions are final. Change cleared for archive.
 -->
 
 ## Q-001: AI-First phases — inline-materialised vs `extends: ai-first`

--- a/.forge/changes/b7-1-schema/open-questions.md
+++ b/.forge/changes/b7-1-schema/open-questions.md
@@ -1,0 +1,116 @@
+# Open Questions — b7-1-schema
+
+<!--
+Tracks unresolved questions per Article III.4 mechanisation
+(`.forge/standards/global/open-questions.md`). Q-NNN sequential, never reused.
+Author phase: leanings recorded; resolutions are made at /forge:design by an
+INDEPENDENT reviewer + the maintainer, not self-approved here.
+
+## Resolution log
+- **Q-001** resolved at /forge:design 2026-06-11 → option (a) inline-materialise. ADR-B7-1-001 finalized. Code-grounded (no scaffold-schema loader resolves `extends`).
+- **Q-002** resolved at /forge:design 2026-06-11 → option (a) candidate+scaffoldable:false, promotion deferred to B.7 scaffolder-flip brick. ADR-B7-1-002 finalized.
+- **Q-003** resolved at /forge:design 2026-06-11 → option (a) reference-only + delivered_by:B.7.3. ADR-B7-1-003 finalized.
+- **Q-004** resolved at /forge:design 2026-06-11 → option (a) Qwik under frontend.surfaces; primary_agent be:Vulcan/fe:Hera/infra:Atlas. ADR-B7-1-004 finalized.
+- NOTE: resolutions authored at design; **maintainer ratification + independent code-reviewer APPROVE pending** at /forge:review (not self-approved — Article V).
+-->
+
+## Q-001: AI-First phases — inline-materialised vs `extends: ai-first`
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-11)
+- **Raised in**: `proposal.md` (ADR-B7-1-001 seed), `specs.md` FR-B7-1-020/021
+- **Raised on**: 2026-06-11
+- **Raised by**: author (b7-1 specify pass)
+
+### Question
+
+Plan §6.2 says `ai-native-rag/1.0.0.yaml` "étend `ai-first` avec phases
+`embeddings-pipeline` et `prompt-audit`". But `ai-first/schema.yaml` is a
+*workflow* schema (extends default + phases, no layers) while the file lives at
+the *archetype scaffold* path (needs layers/components). **No scaffold-schema
+loader resolves `extends`** (`parseSchemaMeta` reads only version/stage/
+scaffoldable; `check_versioned_schema_siblings` reads `phases` from the file
+itself; `grep -rn extends cli/src .forge/scripts` → only Dart hits). So an
+`extends: ai-first` would NOT supply phases and the validator would fail
+`phases missing or empty`.
+
+`[NEEDS CLARIFICATION: materialise the ai-first phases inline into 1.0.0.yaml
+(adding embeddings-pipeline + prompt-audit), keeping extends: ai-first as a
+documentary pointer only — or invest in a loader that resolves extends for
+scaffold schemas (larger, cross-cutting, out of B.7.1 scope)?]`
+
+- (a) **Inline-materialise + documentary `extends`** *(leaning)* — copy the
+  ai-first phase list into `1.0.0.yaml`, add the two B.7.1 phases, retain
+  `extends: ai-first` (or a header comment) for provenance. Self-contained,
+  validates on landing, no loader change. Cost: phase duplication between
+  `ai-first/schema.yaml` and this file (drift risk — mitigated by b7-1.test.sh
+  asserting the AI-First phase set is present).
+- (b) **Build an `extends` resolver for scaffold schemas** — single source of
+  truth, no duplication. Cost: new cross-cutting loader behaviour touching the CLI
+  + the bash validators; large, out of an effort-S brick; would block B.7.1 on a
+  framework change. Rejected for B.7.1 scope (could be a later G.* tooling brick).
+
+## Q-002: candidate → stable/scaffoldable promotion trigger
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-11)
+- **Raised in**: `proposal.md` (ADR-B7-1-002), `specs.md` FR-B7-1-005
+- **Raised on**: 2026-06-11
+
+### Question
+
+The first cut is `candidate` + `scaffoldable: false` (no templates). What promotes
+it to `stable` + `scaffoldable: true`, and which B.7 brick owns the flip?
+
+`[NEEDS CLARIFICATION: confirm the promotion mirrors B.8.14 — flip to
+stable+scaffoldable in the B.7 brick that ships the scaffold-plan + templates +
+green b7-6 harness; and name that brick when the B.7 chain is sequenced.]`
+
+- (a) **Flip in the scaffolder-completion brick, gated on b7-6 harness**
+  *(leaning)* — analogous to B.8.14 C2 (scaffoldable:false→true once a real
+  scaffold is proven green). Keeps init refusing until the archetype actually
+  produces a working tree.
+- (b) Flip earlier (at b7-2 backbone) — rejected: would advertise a scaffoldable
+  archetype before the example/harness prove it, risking a broken `forge init`.
+
+## Q-003: component reference-only + deferred-standard gap
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-11)
+- **Raised in**: `proposal.md` (ADR-B7-1-003), `specs.md` FR-B7-1-031/032
+- **Raised on**: 2026-06-11
+
+### Question
+
+pgvector/Temporal/Zitadel/Connect/Qwik/observability standards exist; LLM
+gateway / MCP / RAG-patterns do not (they are B.7.3). How does the schema
+reference the missing ones without fabricating?
+
+`[NEEDS CLARIFICATION: reference existing standards by filename and mark the three
+missing ones delivered_by: B.7.3 with no inline pin — mirroring the B.8.3
+Envoy-pin-deferred-to-B.8.4 precedent?]`
+
+- (a) **Reference-only + delivered_by: B.7.3 for the gaps** *(leaning)* — mirrors
+  ADR-B8-3-002 + the Envoy gap. No fabrication (Article III.4). No verify-then-pin
+  candidate (`rmcp`, pgvector crate) committed in the schema.
+- (b) Inline pins now — rejected: second source of truth that drifts, and would
+  require fabricating standards/versions that don't exist yet.
+
+## Q-004: layer / RAG-surface modelling + AI-frontend primary_agent
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-11)
+- **Raised in**: `proposal.md` (ADR-B7-1-004), `specs.md` FR-B7-1-011/012
+- **Raised on**: 2026-06-11
+
+### Question
+
+The validator requires backend/frontend/infra. How are the Qwik streaming surface
+and the RAG/MCP backend roles modelled, and which agent owns the AI frontend?
+
+`[NEEDS CLARIFICATION: model the Qwik streaming UI under frontend.surfaces (as
+full-stack 2.0.0 does for web-public), backend primary_agent Vulcan, infra Atlas
+— and decide the frontend primary_agent (Hera vs a web-specific agent) at
+design?]`
+
+- (a) **Qwik surface under `frontend.surfaces`, Vulcan/Atlas for backend/infra**
+  *(leaning)* — reuses the full-stack 2.0.0 surface precedent; exact surface
+  fields + frontend primary_agent finalised at design.
+- (b) New top-level `web-public` layer — rejected: breaks the required-triple
+  invariant shape and diverges from the flagship precedent.

--- a/.forge/changes/b7-1-schema/open-questions.md
+++ b/.forge/changes/b7-1-schema/open-questions.md
@@ -11,7 +11,8 @@ INDEPENDENT reviewer + the maintainer, not self-approved here.
 - **Q-002** resolved at /forge:design 2026-06-11 → option (a) candidate+scaffoldable:false, promotion deferred to B.7 scaffolder-flip brick. ADR-B7-1-002 finalized.
 - **Q-003** resolved at /forge:design 2026-06-11 → option (a) reference-only + delivered_by:B.7.3. ADR-B7-1-003 finalized.
 - **Q-004** resolved at /forge:design 2026-06-11 → option (a) Qwik under frontend.surfaces; primary_agent be:Vulcan/fe:Hera/infra:Atlas. ADR-B7-1-004 finalized.
-- NOTE: resolutions authored at design; **maintainer ratification + independent code-reviewer APPROVE pending** at /forge:review (not self-approved — Article V).
+- **Q-005** raised by the independent reviewer at /forge:review 2026-06-11 (HIGH finding) → option (a): exit 2 accepted as the B.7.1 clean refusal, dispatch-table registration + exit-3 flip deferred to B.7.2. Test + docs corrected; re-verified live 19/19.
+- NOTE: Q-001..Q-004 resolutions authored at design; Q-005 raised + resolved at the independent review pass (Article V — reviewer was a separate context, not self-approval). Maintainer ratification of all five pending final sign-off.
 -->
 
 ## Q-001: AI-First phases — inline-materialised vs `extends: ai-first`
@@ -114,3 +115,45 @@ design?]`
   fields + frontend primary_agent finalised at design.
 - (b) New top-level `web-public` layer — rejected: breaks the required-triple
   invariant shape and diverges from the flagship precedent.
+
+## Q-005: dispatch-table registration gap — `forge init` exit code (2 vs 3)
+
+- **Status**: answered → recorded as a known gap, resolved by B.7.2
+- **Raised in**: independent review of commit 537b658 (HIGH finding), 2026-06-11
+- **Raised by**: independent code-reviewer (caught an integration claim the
+  author stated as verified but had not traced through `init.ts`)
+
+### Question
+
+The change originally asserted (NFR-B7-1-002, design Data Flow, L2 test) that
+`forge init --archetype ai-native-rag` refuses with **exit 3** via
+`selectScaffoldableVersion` null. **That is false today.** Verified live against a
+built CLI: it returns **exit 2** ("unknown archetype"). Root cause:
+`cli/src/commands/init.ts:210-216` checks the dispatch-table FIRST; `ai-native-rag`
+is not in `.forge/scaffolding/dispatch-table.yml`, so the unknown-archetype gate
+fires before the schema-version layer. The exit-3 guard (`init.ts:232-238`) is
+downstream and unreachable for an unregistered archetype.
+
+`[NEEDS CLARIFICATION: is exit 2 (unknown archetype) the acceptable clean-refusal
+for B.7.1 — leaving dispatch-table registration to B.7.2 — or should B.7.1 also
+register ai-native-rag in dispatch-table.yml now?]`
+
+- (a) **Accept exit 2 now; register in B.7.2** *(resolved — reviewer option 1)* —
+  exit 2 is a clean refusal (no scaffold), consistent with the additive,
+  effort-S scope (NFR-B7-1-001: no edits to existing files beyond CI). The L2
+  test, design Data Flow, NFR-B7-1-002, proposal, tasks, and `.forge.yaml` were
+  all corrected to assert exit 2 and to flag that the exit-3 gate activates once
+  **B.7.2** registers `ai-native-rag` in the dispatch-table while keeping the
+  schema candidate/scaffoldable:false. Re-verified live: `FORGE_B7_1_LIVE=1
+  b7-1.test.sh --level 1,2` → 19/19 GREEN.
+- (b) Register in dispatch-table.yml in B.7.1 — rejected: edits an existing file
+  beyond the CI registration (NFR-B7-1-001), and registering an archetype with no
+  scaffolder/templates is B.7.2's job; it would also make exit 3 fire while the
+  scaffolder is still absent, a less honest state than "unknown archetype".
+
+### Lesson (Article III.4)
+
+The schema-version layer was verified in isolation but the full `init.ts` control
+flow was not traced — an integration claim was stated as verified fact. Fixed by
+tracing `init.ts` end-to-end and re-running the live CLI. Recorded so B.7.2 picks
+up the dispatch-table registration + the L2 exit-code flip.

--- a/.forge/changes/b7-1-schema/proposal.md
+++ b/.forge/changes/b7-1-schema/proposal.md
@@ -1,0 +1,204 @@
+# Proposal: b7-1-schema
+
+<!-- Created: 2026-06-11 -->
+<!-- Schema: default -->
+<!-- Audit: B.7.1 (docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0.yaml archetype scaffold schema) -->
+
+## Problem
+
+T7 opens the two new archetypes (plan §6, §11). `ai-native-rag` is the AI-first
+archetype — pgvector + LLM gateway (Mistral-EU / vLLM) + MCP servers + Qwik
+streaming UI. Per the ratified exploration (`.forge/_memory/b7-ai-native-rag-exploration.md`,
+2026-06-11) it is decomposed into a B.8-grain incremental chain; this change is
+**link #1**: the archetype scaffold schema, which every downstream B.7 brick
+(standards, scaffolder, Pythia, compliance, example, harness) validates against.
+
+**Ground truth (re-read 2026-06-11, Article III.4):**
+
+- `ai-native-rag` is **already in the taxonomy enum**:
+  `.forge/schemas/archetype.schema.json:12` lists it with the description
+  "AI-first archetype — pgvector 0.8 + LLM gateway (Mistral-EU / vLLM) + MCP
+  servers + Qwik streaming UI." ⇒ this change does **not** touch the enum.
+
+- **There are two distinct schema families** under `.forge/schemas/`:
+  - *workflow/process schemas* (`default/`, `rapid/`, `tdd-rust/`, `tdd-flutter/`,
+    `ai-first/`, `mobile-only/`) — `schema.yaml` with `extends:` + `phases`, **no
+    `layers`/`components`**. They define a change's dev *process*.
+  - *archetype scaffold schemas* (`full-stack-monorepo/schema.yaml` 1.0.0 +
+    `full-stack-monorepo/2.0.0.yaml`) — `name`/`version`/`stage`/`scaffoldable`/
+    `layers`/`components`/`phases`, **no `extends:`**. They define what
+    `forge init --archetype <name>` produces.
+  Plan §6.2 conflates the two ("`ai-native-rag/1.0.0.yaml` étend `ai-first` avec
+  phases"). The file lives at the *scaffold* path but the plan wants the *process*
+  semantics of `ai-first`. **Recorded, not normalized** (→ ADR-B7-1-001).
+
+- **`extends:` is resolved by NO scaffold-schema loader.** `grep -rn extends
+  cli/src .forge/scripts` returns only Dart-widget matches; `parseSchemaMeta`
+  (`cli/src/domain/schema-version.ts:30`) line-parses only `version`/`stage`/
+  `scaffoldable`; `check_versioned_schema_siblings` reads `layers`/`phases`
+  **directly from the versioned file**. An `extends: ai-first` would NOT inherit
+  phases — the validator would fail `phases missing or empty`. ⇒ the AI-First
+  phases MUST be **inlined** (→ ADR-B7-1-001).
+
+- **The versioned-schema validator already gates this file ON LANDING** (B.8.3.b,
+  `validate-foundations.sh:397 check_versioned_schema_siblings`, generic across
+  all archetype dirs). For `<archetype>/<X.Y.Z>.yaml` it enforces: `name` == dir
+  name; `version` valid SemVer **and** == filename stem; `layers` non-empty list
+  **including backend/frontend/infra**, each with `id`/`path`/`fr_id_prefix`/
+  `primary_agent`; `stage` ∈ {draft,candidate,stable}; **`stage: candidate` ⇒
+  `scaffoldable: false`**; `phases` non-empty. Unlike B.8.3's 2.0.0.yaml (which
+  predated this validator and was invisible), `ai-native-rag/1.0.0.yaml` is
+  validated immediately — it MUST satisfy every invariant the moment it lands.
+
+- **No `schema.yaml` is required** for a non-flagship archetype dir: the
+  existence guard `validate-foundations.sh:92` is hard-coded to
+  `full-stack-monorepo/schema.yaml` only. `ai-native-rag/` may ship with just
+  `1.0.0.yaml`.
+
+- **CLI selection** (`selectScaffoldableVersion`, schema-version.ts:68): picks the
+  highest `stage: stable` + `scaffoldable: true`. A dir whose only version is
+  `candidate`/`scaffoldable:false` returns `null` ⇒ `forge init` refuses (the
+  B.8.3.b refusal, exit 3). Correct for B.7.1: there are no templates yet, so the
+  archetype must NOT be scaffoldable.
+
+- **Component standards — partial gap.** pgvector→`persistence.yaml`,
+  Temporal→`orchestration.yaml`, Zitadel→`identity.yaml`, Connect→`transport.yaml`,
+  Qwik→`web-frontend.yaml`, observability→`observability.yaml` all exist. But
+  **`llm-gateway`, `mcp-servers`, `rag-patterns` standards do NOT exist** — they
+  are B.7.3 (`b7-standards`). Mirrors the B.8.3 Envoy-pin gap exactly. **Recorded,
+  not fabricated** (→ ADR-B7-1-003).
+
+## Solution
+
+Author the **specification for** `.forge/schemas/ai-native-rag/1.0.0.yaml` — its
+required content, the AI-First process it materialises, the component set it
+references, and the candidate/non-scaffoldable rules. Like B.8.3, this change is
+**propose + specify** (the schema file itself is built at the implementation
+phase after design); it ships **no template, no version pin, no scaffolder, and
+edits no existing schema/standard/constitution**.
+
+The `1.0.0.yaml`, when built, MUST:
+
+1. Use the *archetype scaffold schema* shape (parity with
+   `full-stack-monorepo/{schema,2.0.0}.yaml`): `name`, `version`, `stage`,
+   `scaffoldable`, `description`, `tdd_enforced`, `bdd_required_for_user_facing`,
+   `coverage_threshold`, `layers`, `fr_id_prefix_cross_layer`, `cross_layer`,
+   `phases`.
+2. Declare `name: ai-native-rag`, `version: "1.0.0"`, `stage: candidate`,
+   `scaffoldable: false`.
+3. Declare the minimum `layers` triple backend/frontend/infra (validator
+   contract), modelling the RAG topology — Rust backend (RAG pipeline + in-repo
+   LLM gateway proxy + MCP servers), frontend (Qwik streaming UI via `surfaces:`,
+   mirroring full-stack 2.0.0), infra (pgvector/Temporal/Zitadel/observability).
+4. **Inline** the AI-First phases (materialised from `ai-first/schema.yaml`, NOT
+   via `extends`): `ai_brainstorm` (Oracle, gate `fallback_strategy_defined`) →
+   proposal → specs → features → design → tasks → implementation → review →
+   archive, PLUS the two B.7.1 additions: **`embeddings-pipeline`** (specs the
+   chunking/embeddings/retrieval pipeline before design) and **`prompt-audit`**
+   (a gate on prompt-audit logging). Carry the ai-first `ai_specifics`
+   (fallback_mandatory, pii_handling, token_budget, non_determinism_testing).
+5. Declare the component SET **reference-only** (no inline pins, ADR-B8-3-002
+   precedent): pgvector→`persistence.yaml`, Temporal→`orchestration.yaml`,
+   Zitadel→`identity.yaml`, Connect→`transport.yaml`, Qwik→`web-frontend.yaml`,
+   observability→`observability.yaml`; and **reference the deferred standards**
+   for the in-repo LLM gateway, MCP servers, and RAG patterns (delivered by B.7.3)
+   — recorded as a gap, never fabricated.
+6. Carry a header block documenting candidate semantics: not scaffoldable while no
+   templates exist; promotion to `stable` + `scaffoldable: true` happens at the
+   later B.7 brick that ships + proves the scaffolder/templates (analogous to the
+   B.8.14 flip), gated on the B.7 harness.
+
+Decisions reserved for `/forge:design` (ADRs); leanings stated, genuinely
+undecided points in `open-questions.md`:
+
+- **ADR-B7-1-001 — phases: inline (materialised) vs `extends: ai-first`.** Lean:
+  **inline** the ai-first phases + add `embeddings-pipeline`/`prompt-audit`,
+  because no scaffold-schema loader resolves `extends` (grounded above). Keep an
+  `extends: ai-first` key (or a header comment) as documentary provenance only;
+  the validator-load path reads the inlined phases. Resolves the §6.2 conflation.
+- **ADR-B7-1-002 — stage/scaffoldable for the first cut.** Lean: `candidate` +
+  `scaffoldable: false` (validator-enforced; init refuses cleanly via exit 3).
+  Promotion to `stable` deferred to the B.7 scaffolder-flip brick after the B.7
+  harness proves a green scaffold (mirrors B.8.14). The exact promotion brick id
+  is set when the B.7 chain is sequenced.
+- **ADR-B7-1-003 — components reference-only + deferred-standard gap.** Lean:
+  reference-only (mirror ADR-B8-3-002). LLM-gateway/MCP/rag standards do not exist
+  yet → reference them as `delivered_by: B.7.3` with no inline pin; record the gap
+  (Article III.4 — no fabrication).
+- **ADR-B7-1-004 — layer / RAG-surface modelling.** Lean: backend/frontend/infra
+  triple with the Qwik streaming surface under `frontend.surfaces` (full-stack
+  2.0.0 precedent). Exact `layers[]`/`surfaces` shape + `primary_agent` for the AI
+  frontend decided at design.
+
+Release vehicle: maintainer-set (additive spec artifact; no runtime change).
+
+## Scope In
+
+- `proposal.md`, `specs.md`, `.forge.yaml`, `open-questions.md` for
+  `b7-1-schema` (this change): requirement set + ADRs + open questions for the
+  `ai-native-rag / 1.0.0` candidate scaffold schema.
+- Requirements `FR-B7-1-*` / `NFR-B7-1-*` defining WHAT the schema file must
+  contain and the candidate/non-scaffoldable rules.
+- ADRs `ADR-B7-1-001..004` (phases-inline, stage, components, layers).
+
+## Scope Out (Explicit Exclusions)
+
+- **Building the `1.0.0.yaml` file itself** — implementation phase of B.7.1,
+  authored AFTER design from these specs. NOT created now.
+- **Templates** `templates/ai-native-rag/**` — B.7.2 (`b7-2-scaffolder`).
+- **Standards** `llm-gateway.md` / `mcp-servers.md` / `rag-patterns.md` — B.7.3
+  (`b7-standards`). This change references them as deferred; it bumps/creates none.
+- **Scaffolder + promotion to stable/scaffoldable** — later B.7 brick.
+- **Agent Pythia (K.2)** — `b7-pythia`.
+- **Janus AI refusal rules / J.8.c** — `b7-9-janus-ai`.
+- **Constitution amendment** — none. `ai-native-rag` consumes §VIII.1 (Envoy) +
+  §VIII.2 (Temporal) as-is; it changes no invoked article.
+- **Component version pins** — owned by the referenced standards; never inlined.
+
+## Impact
+
+- **Users affected**: B.7 archetype authors (the schema is the shared contract
+  gating the rest of the B.7 chain). **Zero** effect on existing adopters: no
+  current archetype is touched; `ai-native-rag` is not scaffoldable yet, so
+  `forge init --archetype ai-native-rag` refuses cleanly (exit 3) rather than
+  emitting a broken scaffold.
+- **Technical impact**: spec artifacts only in this change. The schema file is a
+  new sibling validated on landing by `check_versioned_schema_siblings`.
+- **Dependencies**: B.8.3.b (the generic versioned-schema validator this file
+  must satisfy) + B.8.14 (the CLI selection/refusal path). Gates B.7.2, B.7.3 and
+  the rest of the B.7 chain.
+
+## Constitution Compliance
+
+- **Article III.1/III.2 (Specs before code)**: propose+specify gate; the schema
+  file is built only after design.
+- **Article III.4 (Anti-Hallucination)**: every claim about the two schema
+  families, `extends` non-resolution, the versioned validator contract, CLI
+  selection, and the standard gaps is re-read from live files
+  (`schema-version.ts`, `validate-foundations.sh`, `archetype.schema.json`,
+  `ai-first/schema.yaml`, `full-stack-monorepo/2.0.0.yaml`). The §6.2 conflation
+  and the missing LLM-gateway/MCP/rag standards are **recorded, not normalised**;
+  the verify-then-pin candidates (`rmcp`, pgvector Rust crate) are explicitly NOT
+  pinned here.
+- **Article IV (Delta-based)**: purely additive — no existing schema/standard is
+  edited; the file is a new sibling.
+- **Article XI (AI-First Design)**: the inlined phases materialise XI.5 (mandatory
+  fallback — `ai_brainstorm` gate `fallback_strategy_defined`, `ai_fallback_required`)
+  and XI.6 (PII protection — `pii_handling: explicit_consent_required`); the
+  `prompt-audit` phase + `token_budget` support Article IX.6 (AI feature
+  observability: token counts, fallback invocations).
+- **Article V (Compliance gate)**: each open question maps to a design-phase ADR
+  resolved by an independent reviewer + maintainer; no work proceeds around an
+  unresolved naming/phase/component question.
+- **Article XII (Governance)**: no amendment here.
+
+## Open Questions (seed)
+
+- **Q-001** — phases inline-materialised vs `extends: ai-first` (→ ADR-B7-1-001;
+  leaning inline, see `open-questions.md`).
+- **Q-002** — candidate→stable/scaffoldable promotion trigger + which B.7 brick
+  owns the flip (→ ADR-B7-1-002; open, resolved at design).
+- **Q-003** — component reference-only + deferred-standard gap handling
+  (→ ADR-B7-1-003; leaning reference-only).
+- **Q-004** — layer/RAG-surface modelling + AI-frontend `primary_agent`
+  (→ ADR-B7-1-004; open, resolved at design).

--- a/.forge/changes/b7-1-schema/proposal.md
+++ b/.forge/changes/b7-1-schema/proposal.md
@@ -57,9 +57,12 @@ streaming UI. Per the ratified exploration (`.forge/_memory/b7-ai-native-rag-exp
 
 - **CLI selection** (`selectScaffoldableVersion`, schema-version.ts:68): picks the
   highest `stage: stable` + `scaffoldable: true`. A dir whose only version is
-  `candidate`/`scaffoldable:false` returns `null` ⇒ `forge init` refuses (the
-  B.8.3.b refusal, exit 3). Correct for B.7.1: there are no templates yet, so the
-  archetype must NOT be scaffoldable.
+  `candidate`/`scaffoldable:false` returns `null` (the B.8.3.b exit-3 refusal in
+  isolation). **NB (verified live, corrected post-review):** `init.ts:210` checks
+  the dispatch-table FIRST, so an archetype not registered there refuses earlier
+  with **exit 2** (unknown archetype); the exit-3 path is reachable only once B.7.2
+  registers `ai-native-rag` (Q-005). Correct for B.7.1 either way: there are no
+  templates yet, so the archetype must NOT be scaffoldable and init refuses cleanly.
 
 - **Component standards — partial gap.** pgvector→`persistence.yaml`,
   Temporal→`orchestration.yaml`, Zitadel→`identity.yaml`, Connect→`transport.yaml`,
@@ -117,7 +120,8 @@ undecided points in `open-questions.md`:
   `extends: ai-first` key (or a header comment) as documentary provenance only;
   the validator-load path reads the inlined phases. Resolves the §6.2 conflation.
 - **ADR-B7-1-002 — stage/scaffoldable for the first cut.** Lean: `candidate` +
-  `scaffoldable: false` (validator-enforced; init refuses cleanly via exit 3).
+  `scaffoldable: false` (validator-enforced; init refuses cleanly — exit 2 today
+  via the dispatch-table gate, exit 3 once registered by B.7.2, Q-005).
   Promotion to `stable` deferred to the B.7 scaffolder-flip brick after the B.7
   harness proves a green scaffold (mirrors B.8.14). The exact promotion brick id
   is set when the B.7 chain is sequenced.
@@ -160,8 +164,8 @@ Release vehicle: maintainer-set (additive spec artifact; no runtime change).
 - **Users affected**: B.7 archetype authors (the schema is the shared contract
   gating the rest of the B.7 chain). **Zero** effect on existing adopters: no
   current archetype is touched; `ai-native-rag` is not scaffoldable yet, so
-  `forge init --archetype ai-native-rag` refuses cleanly (exit 3) rather than
-  emitting a broken scaffold.
+  `forge init --archetype ai-native-rag` refuses cleanly (exit 2 today — unknown
+  archetype, dispatch-table-gated) rather than emitting a broken scaffold.
 - **Technical impact**: spec artifacts only in this change. The schema file is a
   new sibling validated on landing by `check_versioned_schema_siblings`.
 - **Dependencies**: B.8.3.b (the generic versioned-schema validator this file

--- a/.forge/changes/b7-1-schema/specs.md
+++ b/.forge/changes/b7-1-schema/specs.md
@@ -25,7 +25,7 @@ fallback, XI.6 PII), IX.6 (AI feature observability), X.1 (80% coverage).
 | **`extends` resolution (observed gap)** | No scaffold-schema loader resolves `extends`: `grep -rn extends cli/src .forge/scripts` → only Dart-widget hits; `parseSchemaMeta` (schema-version.ts:30) reads version/stage/scaffoldable only; `check_versioned_schema_siblings` reads layers/phases from the file itself. ⇒ phases MUST be inlined. |
 | **Versioned validator (observed)** | `validate-foundations.sh:397 check_versioned_schema_siblings` (B.8.3.b) — generic over all archetype dirs; enforces name==dir, version==filename+SemVer, layers ⊇ {backend,frontend,infra} (each id/path/fr_id_prefix/primary_agent), stage∈{draft,candidate,stable}, candidate⇒scaffoldable:false, phases non-empty. **Gates this file on landing.** |
 | **schema.yaml requirement (observed)** | `validate-foundations.sh:92` hard-codes `full-stack-monorepo/schema.yaml` only. A non-flagship archetype dir may ship just `1.0.0.yaml`. |
-| **CLI selection (observed)** | `selectScaffoldableVersion` (schema-version.ts:68) picks highest stable+scaffoldable; candidate/scaffoldable:false ⇒ null ⇒ `forge init` refuses (exit 3, the B.8.3.b refusal). |
+| **CLI selection (observed)** | `selectScaffoldableVersion` (schema-version.ts:68) picks highest stable+scaffoldable; candidate/scaffoldable:false ⇒ null. In isolation this yields the B.8.3.b exit-3 refusal — but `init.ts:210` checks the dispatch-table FIRST, so an unregistered archetype refuses earlier with **exit 2** (verified live). exit-3 is reachable only post-registration (Q-005). |
 | **Component standards (observed)** | EXIST: `persistence.yaml` (postgres-17 + pgvector-0.8), `orchestration.yaml` v1.2.0 (default_by_language.rust: temporal), `identity.yaml` (zitadel), `transport.yaml` (connect-rpc), `web-frontend.yaml` (qwik, B.8.9), `observability.yaml` v2.1.0. ABSENT: `llm-gateway` / `mcp-servers` / `rag-patterns` → B.7.3 (gap, ADR-B7-1-003). |
 | **ai-first phases (observed)** | `ai-first/schema.yaml`: `ai_brainstorm`(gate fallback_strategy_defined)→proposal→specs→features→design→tasks→implementation→review→archive; `ai_specifics`{fallback_mandatory, pii_handling, token_budget_documented, non_determinism_testing}. |
 | **Constitution AI articles (observed)** | XI.1 agent-native, XI.3 GenUI schema-driven, XI.4 event-driven frontend, XI.5 mandatory fallback, XI.6 PII protection; IX.6 AI feature observability (token counts, fallback invocations). |
@@ -55,8 +55,12 @@ filename↔version invariant (`X.Y.Z.yaml` ⇒ `version: "X.Y.Z"`) holds.
 
 ##### FR-B7-1-003 — non-scaffoldable candidate
 MUST declare `scaffoldable: false` (b8-3b enforces candidate⇒scaffoldable:false).
-Consequence (must hold, NFR-B7-1-002): `selectScaffoldableVersion` returns null ⇒
-`forge init --archetype ai-native-rag` refuses (exit 3), never a broken scaffold.
+Consequence (must hold, NFR-B7-1-002): `forge init --archetype ai-native-rag`
+refuses cleanly, never a broken scaffold. **Verified gate today = exit 2**
+("unknown archetype": `init.ts:210` dispatch-table check, ai-native-rag not yet
+registered). The `selectScaffoldableVersion`-null → **exit 3** path
+(`init.ts:232`) is the gate once B.7.2 registers the archetype while the schema
+stays candidate/scaffoldable:false (Q-005).
 
 ##### FR-B7-1-004 — TDD/BDD/coverage flags
 MUST carry `tdd_enforced: true`, `bdd_required_for_user_facing: true`,
@@ -144,9 +148,12 @@ CLI, or any template. `git diff --name-only` MUST show only new files under
 `.forge/changes/b7-1-schema/` (+ the schema file + its harness at impl phase).
 
 ##### NFR-B7-1-002 — clean non-scaffoldable behaviour (no broken init)
-After the schema lands, `forge init --archetype ai-native-rag` MUST refuse via the
-existing `selectScaffoldableVersion` null path (exit 3), never emit a partial
-scaffold. No other archetype's init behaviour changes.
+After the schema lands, `forge init --archetype ai-native-rag` MUST refuse
+cleanly and emit no partial scaffold. **Today the refusal is exit 2** (unknown
+archetype — the `init.ts:210` dispatch-table gate fires first, ai-native-rag not
+registered). It shifts to exit 3 (`selectScaffoldableVersion` null,
+`init.ts:232`) once B.7.2 registers the archetype while keeping the schema
+candidate/scaffoldable:false (Q-005). No other archetype's init behaviour changes.
 
 ##### NFR-B7-1-003 — validators stay GREEN on landing
 After the schema file lands (impl phase), `validate-foundations.sh`
@@ -182,7 +189,8 @@ gap. Registered in `forge-ci.yml`. (Authored at impl; specified here.)
 1. `.forge/schemas/ai-native-rag/1.0.0.yaml` exists; `name`/`version`/`stage`/
    `scaffoldable` = ai-native-rag/1.0.0/candidate/false.
 2. `validate-foundations.sh` → `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS.
-3. `forge init --archetype ai-native-rag` → exit 3 (refused, not scaffoldable).
+3. `forge init <name> --archetype ai-native-rag --org <rd>` → exit 2 (refused —
+   unknown archetype, dispatch-table-gated; exit 3 once B.7.2 registers it, Q-005).
 4. `layers` ⊇ {backend,frontend,infra}; Qwik surface under `frontend.surfaces`.
 5. Inlined phases include `ai_brainstorm` + `embeddings-pipeline` + `prompt-audit`;
    `ai_specifics` present.

--- a/.forge/changes/b7-1-schema/specs.md
+++ b/.forge/changes/b7-1-schema/specs.md
@@ -1,0 +1,192 @@
+# Specifications: b7-1-schema
+
+<!-- Status: specified -->
+<!-- Schema: default -->
+<!-- Audit: B.7.1 (docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0 archetype scaffold schema) -->
+
+**Namespace** : `FR-B7-1-*` / `NFR-B7-1-*` / `ADR-B7-1-*`.
+**Constitution** : v2.0.0, unchanged. This change is **propose + specify only**.
+It authors the requirements + ADRs for the `ai-native-rag / 1.0.0` **candidate**
+archetype scaffold schema. It ships **no schema file, no template, no version
+pin, and edits no existing schema/standard**. The file is built at the impl
+phase (after design); templates + standards arrive in B.7.2 / B.7.3.
+**Governing articles** : III.1/III.2 (specs before code), III.4
+(Anti-Hallucination), IV (delta-based / additive), XI (AI-First Design — XI.5
+fallback, XI.6 PII), IX.6 (AI feature observability), X.1 (80% coverage).
+
+## Source Documents
+
+| Field | Value |
+|-------|-------|
+| **Plan ref** | `docs/new-archetypes-plan.md` §6.2 B.7.1 (`ai-native-rag/1.0.0.yaml`, extends `ai-first` + phases `embeddings-pipeline`/`prompt-audit`, effort S), §11 (T7) |
+| **Exploration** | `.forge/_memory/b7-ai-native-rag-exploration.md` (ratified 2026-06-11): B.7 first, in-repo LLM gateway, incremental chain, Pythia standalone |
+| **Taxonomy enum (observed)** | `.forge/schemas/archetype.schema.json:12` already lists `ai-native-rag` — enum NOT touched by this change |
+| **Two schema families (observed)** | *workflow* schemas (`ai-first/schema.yaml`: `extends: default` + phases, no layers) vs *archetype scaffold* schemas (`full-stack-monorepo/{schema,2.0.0}.yaml`: layers/components/phases, no `extends`). §6.2 conflates them (→ ADR-B7-1-001). |
+| **`extends` resolution (observed gap)** | No scaffold-schema loader resolves `extends`: `grep -rn extends cli/src .forge/scripts` → only Dart-widget hits; `parseSchemaMeta` (schema-version.ts:30) reads version/stage/scaffoldable only; `check_versioned_schema_siblings` reads layers/phases from the file itself. ⇒ phases MUST be inlined. |
+| **Versioned validator (observed)** | `validate-foundations.sh:397 check_versioned_schema_siblings` (B.8.3.b) — generic over all archetype dirs; enforces name==dir, version==filename+SemVer, layers ⊇ {backend,frontend,infra} (each id/path/fr_id_prefix/primary_agent), stage∈{draft,candidate,stable}, candidate⇒scaffoldable:false, phases non-empty. **Gates this file on landing.** |
+| **schema.yaml requirement (observed)** | `validate-foundations.sh:92` hard-codes `full-stack-monorepo/schema.yaml` only. A non-flagship archetype dir may ship just `1.0.0.yaml`. |
+| **CLI selection (observed)** | `selectScaffoldableVersion` (schema-version.ts:68) picks highest stable+scaffoldable; candidate/scaffoldable:false ⇒ null ⇒ `forge init` refuses (exit 3, the B.8.3.b refusal). |
+| **Component standards (observed)** | EXIST: `persistence.yaml` (postgres-17 + pgvector-0.8), `orchestration.yaml` v1.2.0 (default_by_language.rust: temporal), `identity.yaml` (zitadel), `transport.yaml` (connect-rpc), `web-frontend.yaml` (qwik, B.8.9), `observability.yaml` v2.1.0. ABSENT: `llm-gateway` / `mcp-servers` / `rag-patterns` → B.7.3 (gap, ADR-B7-1-003). |
+| **ai-first phases (observed)** | `ai-first/schema.yaml`: `ai_brainstorm`(gate fallback_strategy_defined)→proposal→specs→features→design→tasks→implementation→review→archive; `ai_specifics`{fallback_mandatory, pii_handling, token_budget_documented, non_determinism_testing}. |
+| **Constitution AI articles (observed)** | XI.1 agent-native, XI.3 GenUI schema-driven, XI.4 event-driven frontend, XI.5 mandatory fallback, XI.6 PII protection; IX.6 AI feature observability (token counts, fallback invocations). |
+| **Verify-then-pin candidates (NOT pinned here)** | `rmcp` (README 0.16.0 vs Context7 index 0.5.0 — confirm LIVE at B.7.2/B.7.3), pgvector Rust crate (sqlx feature). |
+| **Downstream gated by this** | B.7.2 (`b7-2-scaffolder`), B.7.3 (`b7-standards`), `b7-pythia`, `b7-9-janus-ai`, `b7-5-ai-act`, `b7-7-example`, `b7-6-harness` |
+| **Release target** | maintainer-set |
+
+---
+
+## ADDED Requirements
+
+### Functional Requirements
+
+#### Cluster 1 — Schema identity & shape (FR-B7-1-001 → 005)
+
+##### FR-B7-1-001 — archetype-scaffold-schema shape (not a workflow schema)
+The file, when authored, MUST use the archetype scaffold schema top-level key set
+(parity with `full-stack-monorepo/2.0.0.yaml`): `name`, `version`, `stage`,
+`scaffoldable`, `description`, `tdd_enforced`, `bdd_required_for_user_facing`,
+`coverage_threshold`, `layers`, `fr_id_prefix_cross_layer`, `cross_layer`,
+`phases`. It MUST NOT be authored as a bare workflow schema (no layers).
+
+##### FR-B7-1-002 — identity fields + filename↔version invariant
+MUST declare `name: ai-native-rag`, `version: "1.0.0"`, `stage: candidate`. The
+file MUST be `.forge/schemas/ai-native-rag/1.0.0.yaml` so the b8-3b
+filename↔version invariant (`X.Y.Z.yaml` ⇒ `version: "X.Y.Z"`) holds.
+
+##### FR-B7-1-003 — non-scaffoldable candidate
+MUST declare `scaffoldable: false` (b8-3b enforces candidate⇒scaffoldable:false).
+Consequence (must hold, NFR-B7-1-002): `selectScaffoldableVersion` returns null ⇒
+`forge init --archetype ai-native-rag` refuses (exit 3), never a broken scaffold.
+
+##### FR-B7-1-004 — TDD/BDD/coverage flags
+MUST carry `tdd_enforced: true`, `bdd_required_for_user_facing: true`,
+`coverage_threshold: 80` (Articles I, II, X.1 not relaxed).
+
+##### FR-B7-1-005 — candidate header block
+MUST carry a header block stating, for THIS file: what `candidate` means while no
+templates exist (not scaffoldable), the promotion trigger to `stable` +
+`scaffoldable: true` (the later B.7 scaffolder-flip brick, gated on a green B.7
+harness — ADR-B7-1-002), and that it is additive (no existing archetype affected).
+
+#### Cluster 2 — Layers & RAG topology (FR-B7-1-010 → 013)
+
+##### FR-B7-1-010 — minimum layer triple
+`layers` MUST be a non-empty list including `backend`, `frontend`, `infra`, each
+with `id`/`path`/`fr_id_prefix`/`primary_agent` (b8-3b validator contract).
+
+##### FR-B7-1-011 — RAG layer roles
+The layers MUST model the RAG topology: backend = Rust (RAG pipeline + in-repo LLM
+gateway proxy + MCP servers; `primary_agent: Vulcan`); frontend = Qwik streaming
+UI; infra = pgvector/Temporal/Zitadel/observability (`primary_agent: Atlas`).
+
+##### FR-B7-1-012 — Qwik streaming surface
+The Qwik streaming UI MUST be modelled under `frontend.surfaces` (mirroring
+`full-stack-monorepo/2.0.0.yaml` `frontend.surfaces`), not as a new top-level
+layer (keeps the required-triple invariant intact). Exact shape + the frontend
+`primary_agent` are design-decided (ADR-B7-1-004).
+
+##### FR-B7-1-013 — cross-layer routing parity
+MUST declare `fr_id_prefix_cross_layer: FR-GL-` and a `cross_layer` block routing
+≥2-layer changes to Janus (parity with the flagship schema).
+
+#### Cluster 3 — Phases & AI-First process (FR-B7-1-020 → 024)
+
+##### FR-B7-1-020 — phases inlined, not inherited
+`phases` MUST be a non-empty list authored **inline**. The schema MUST NOT rely on
+`extends: ai-first` to supply phases (no loader resolves it; the validator reads
+the file's own `phases`). An `extends: ai-first` key MAY be retained as
+documentary provenance only (ADR-B7-1-001).
+
+##### FR-B7-1-021 — AI-First phases materialised
+The inlined phases MUST materialise the `ai-first/schema.yaml` flow:
+`ai_brainstorm` (agent Oracle, gate `fallback_strategy_defined`) → proposal →
+specs → features → design → tasks → implementation → review → archive.
+
+##### FR-B7-1-022 — `embeddings-pipeline` phase (B.7.1 addition)
+MUST add an `embeddings-pipeline` phase (per §6.2) that specs the
+chunking/embeddings/retrieval/re-ranking pipeline **before** design.
+
+##### FR-B7-1-023 — `prompt-audit` phase/gate (B.7.1 addition)
+MUST add a `prompt-audit` gate (per §6.2) requiring prompt-audit logging — wiring
+Article IX.6 (token counts, fallback invocations traced).
+
+##### FR-B7-1-024 — ai_specifics carried
+MUST carry the ai-first `ai_specifics` block: `fallback_mandatory: true` (XI.5),
+`pii_handling: explicit_consent_required` (XI.6), `token_budget_documented: true`,
+`non_determinism_testing` strategy. `ai_fallback_required: true` at top level.
+
+#### Cluster 4 — Component set (reference-only) (FR-B7-1-030 → 032)
+
+##### FR-B7-1-030 — declare the component SET by name
+MUST declare the components by name + role: pgvector (persistence), LLM gateway
+(in-repo proxy, AI inference), MCP servers (tooling), Temporal (orchestration),
+Zitadel (identity), Connect-RPC (transport), Qwik (web-public surface),
+SigNoz/OBI/Coroot (observability).
+
+##### FR-B7-1-031 — reference source standards, no inline pins
+For each component with an existing standard the schema MUST reference it (no
+inline pin, ADR-B8-3-002 precedent): pgvector→`persistence.yaml`,
+Temporal→`orchestration.yaml`, Zitadel→`identity.yaml`, Connect→`transport.yaml`,
+Qwik→`web-frontend.yaml`, observability→`observability.yaml`.
+
+##### FR-B7-1-032 — deferred-standard gap recorded, not fabricated
+For LLM gateway / MCP servers / RAG patterns (no standard today) the schema MUST
+reference them as `delivered_by: B.7.3` with **no** inline version pin and **no**
+fabricated standard filename presented as existing (Article III.4). The
+verify-then-pin candidates (`rmcp`, pgvector Rust crate) MUST NOT be pinned in
+this schema.
+
+### Non-Functional Requirements
+
+##### NFR-B7-1-001 — additive only / zero edit to existing surfaces
+The change MUST NOT modify any existing schema, standard, the constitution, the
+CLI, or any template. `git diff --name-only` MUST show only new files under
+`.forge/changes/b7-1-schema/` (+ the schema file + its harness at impl phase).
+
+##### NFR-B7-1-002 — clean non-scaffoldable behaviour (no broken init)
+After the schema lands, `forge init --archetype ai-native-rag` MUST refuse via the
+existing `selectScaffoldableVersion` null path (exit 3), never emit a partial
+scaffold. No other archetype's init behaviour changes.
+
+##### NFR-B7-1-003 — validators stay GREEN on landing
+After the schema file lands (impl phase), `validate-foundations.sh`
+(`check_versioned_schema_siblings`) MUST emit
+`FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS, and `verify.sh` +
+`constitution-linter.sh` MUST stay GREEN (no regression). The schema MUST satisfy
+every b8-3b invariant the moment it is committed.
+
+##### NFR-B7-1-004 — dedicated harness
+The impl phase MUST add `.forge/scripts/tests/b7-1.test.sh` asserting the
+AI-specific content not covered by the generic validator: the inlined AI-First
+phases incl. `ai_brainstorm`/`embeddings-pipeline`/`prompt-audit`, the
+`ai_specifics` block, the reference-only component set, and the deferred-standard
+gap. Registered in `forge-ci.yml`. (Authored at impl; specified here.)
+
+---
+
+## ADRs (seeded — resolved at /forge:design by independent reviewer + maintainer)
+
+- **ADR-B7-1-001** — phases inline-materialised (lean) vs `extends: ai-first`.
+  Grounded: no scaffold-schema loader resolves `extends`. Resolves §6.2 conflation.
+- **ADR-B7-1-002** — `candidate` + `scaffoldable: false` (lean); promotion to
+  stable deferred to the B.7 scaffolder-flip brick (mirrors B.8.14). Which brick
+  owns the flip = open.
+- **ADR-B7-1-003** — components reference-only (lean); LLM-gateway/MCP/rag
+  standards referenced as `delivered_by: B.7.3`, gap recorded, no fabrication.
+- **ADR-B7-1-004** — layer/RAG-surface modelling + AI-frontend `primary_agent` =
+  design-decided (Qwik surface under `frontend.surfaces`, full-stack 2.0.0
+  precedent).
+
+## Acceptance Criteria (for the impl phase, summarised)
+
+1. `.forge/schemas/ai-native-rag/1.0.0.yaml` exists; `name`/`version`/`stage`/
+   `scaffoldable` = ai-native-rag/1.0.0/candidate/false.
+2. `validate-foundations.sh` → `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS.
+3. `forge init --archetype ai-native-rag` → exit 3 (refused, not scaffoldable).
+4. `layers` ⊇ {backend,frontend,infra}; Qwik surface under `frontend.surfaces`.
+5. Inlined phases include `ai_brainstorm` + `embeddings-pipeline` + `prompt-audit`;
+   `ai_specifics` present.
+6. Components reference-only; no inline pin; LLM-gateway/MCP/rag marked
+   `delivered_by: B.7.3`.
+7. `b7-1.test.sh` GREEN; `verify.sh` + `constitution-linter.sh` no regression.
+8. No existing schema/standard/constitution/CLI/template modified.

--- a/.forge/changes/b7-1-schema/tasks.md
+++ b/.forge/changes/b7-1-schema/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: b7-1-schema
+
+<!-- Status: implemented -->
+<!-- Schema: default -->
+<!-- Audit: B.7.1 (docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0 archetype scaffold schema) -->
+
+TDD-ordered (Article I — RED before GREEN, always). The deliverable is one
+declarative schema file + its dedicated harness. Per design.md the harness is
+authored FIRST and must fail (no schema file) before the schema is written.
+Constitution gate run per task (results inline; none blocks).
+
+## Phase 1: RED — failing harness
+
+- [x] **T1.1** Author `.forge/scripts/tests/b7-1.test.sh` skeleton (bash thin +
+  Python 3 inline, **no pyyaml** for the grep-level asserts — mirror `b8-3.test.sh`
+  pattern; `--level 1` L1 hermetic). Assertions: schema file exists at
+  `.forge/schemas/ai-native-rag/1.0.0.yaml`; `name: ai-native-rag` / `version:
+  "1.0.0"` / `stage: candidate` / `scaffoldable: false`; layers ⊇ {backend,
+  frontend,infra} each with id/path/fr_id_prefix/primary_agent; `frontend.surfaces`
+  has a `qwik` web-public entry; inlined `phases` include `ai_brainstorm` +
+  `embeddings-pipeline` + `prompt-audit`; `ai_specifics` block present
+  (fallback_mandatory/pii_handling/token_budget); components are reference-only
+  (no inline version pin) and `llm-gateway`/`mcp-servers`/`rag-pipeline` carry
+  `delivered_by: B.7.3`. [Story: FR-B7-1-001..032, NFR-B7-1-004]
+- [x] **T1.2** Run `bash .forge/scripts/tests/b7-1.test.sh --level 1` → **verify
+  RED** (schema file absent ⇒ all content asserts fail-loud). Capture the RED
+  output as evidence. [Gate: Article I — must observe failure before GREEN]
+
+## Phase 2: GREEN — author the schema file
+
+- [x] **T2.1** Create `.forge/schemas/ai-native-rag/1.0.0.yaml` with the candidate
+  header block + identity fields `name: ai-native-rag`, `version: "1.0.0"`,
+  `stage: candidate`, `scaffoldable: false` (filename↔version invariant; b8-3b
+  candidate⇒scaffoldable:false). [Story: FR-B7-1-002/003/005]
+- [x] **T2.2** Add `tdd_enforced: true`, `bdd_required_for_user_facing: true`,
+  `coverage_threshold: 80`, `ai_fallback_required: true`, `description`. [Story:
+  FR-B7-1-004] [P]
+- [x] **T2.3** Add `layers` triple (backend→Vulcan, frontend→Hera with
+  `surfaces:[web-public/qwik]`, infra→Atlas) + `fr_id_prefix_cross_layer: FR-GL-`
+  + `cross_layer.agent: Janus` (layers_count_ge 2). [Story: FR-B7-1-010..013,
+  ADR-B7-1-004] [P]
+- [x] **T2.4** Add the **inlined** `phases` (ai_brainstorm → proposal → specs →
+  `embeddings-pipeline` → features → design → `prompt-audit` → tasks →
+  implementation → review → archive) + `extends: ai-first` documentary key
+  (commented non-load-bearing) + `ai_specifics` block. [Story: FR-B7-1-020..024,
+  ADR-B7-1-001] [P]
+- [x] **T2.5** Add `components` reference-only: existing standards by filename
+  (persistence/orchestration/identity/transport/web-frontend/observability) +
+  `llm-gateway`/`mcp-servers`/`rag-pipeline` marked `delivered_by: B.7.3` with NO
+  inline pin (no `rmcp`/pgvector-crate version committed). [Story: FR-B7-1-030..032,
+  ADR-B7-1-003] [P]
+- [x] **T2.6** Run `b7-1.test.sh --level 1` → **verify GREEN** (all asserts pass).
+  [Gate: Article I — GREEN observed]
+
+## Phase 3: Integration
+
+- [x] **T3.1** Run `bash .forge/scripts/validate-foundations.sh` → confirm
+  `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` **PASS** (the b8-3b generic
+  validator now sees the new sibling). [Story: NFR-B7-1-003]
+- [x] **T3.2** Confirm `forge init --archetype ai-native-rag` → **exit 3**
+  (refused, not scaffoldable via `selectScaffoldableVersion` null). Optional L2
+  fixture in `b7-1.test.sh` (`--level 2`, skip-pass if CLI not built). [Story:
+  NFR-B7-1-002]
+- [x] **T3.3** Register `b7-1.test.sh` in `.github/workflows/forge-ci.yml` test
+  matrix (after the prior B.7 entry / per array order). [Story: NFR-B7-1-004]
+
+## Phase 4: Quality
+
+- [x] **T4.1** Run `verify.sh` + `constitution-linter.sh` → **no regression**
+  (OVERALL PASS). [Story: NFR-B7-1-003]
+- [x] **T4.2** `git diff --name-only` → only NEW files (the schema + harness +
+  CI-matrix line + change artifacts); **no existing schema/standard/constitution/
+  CLI/template edited**. [Story: NFR-B7-1-001]
+- [x] **T4.3** REFACTOR: tidy header comments / section anchors; re-run the full
+  `b7-1.test.sh` + `validate-foundations.sh` → still GREEN. [Gate: behavior
+  unchanged]
+- [ ] **T4.4** `/forge:review b7-1-schema` — **independent code-reviewer APPROVE +
+  maintainer ratification** of ADR-B7-1-001..004 (Article V — not self-approved;
+  the design-phase resolutions are pending ratification per open-questions.md).
+
+## Constitution Gate (per task) — summary
+- TDD order enforced: harness RED (T1.2) precedes schema GREEN (T2.6). ✓
+- No spec bypass: every task cites its FR/NFR/ADR. ✓
+- Architecture: additive config schema, no Flutter/Rust/infra code; §VIII consumed
+  as-is; XI materialised. ✓
+- **No [TASK VIOLATION].**
+
+## Parallelization notes
+- T2.2–T2.5 are `[P]` — independent sections of the same file; author together,
+  then the single GREEN gate (T2.6) validates the assembled file.
+- Phase 3 is sequential after a green Phase 2.

--- a/.forge/changes/b7-1-schema/tasks.md
+++ b/.forge/changes/b7-1-schema/tasks.md
@@ -57,9 +57,12 @@ Constitution gate run per task (results inline; none blocks).
 - [x] **T3.1** Run `bash .forge/scripts/validate-foundations.sh` → confirm
   `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` **PASS** (the b8-3b generic
   validator now sees the new sibling). [Story: NFR-B7-1-003]
-- [x] **T3.2** Confirm `forge init --archetype ai-native-rag` → **exit 3**
-  (refused, not scaffoldable via `selectScaffoldableVersion` null). Optional L2
-  fixture in `b7-1.test.sh` (`--level 2`, skip-pass if CLI not built). [Story:
+- [x] **T3.2** Confirm `forge init <name> --archetype ai-native-rag --org <rd>`
+  → **exit 2** (clean refusal — "unknown archetype"; `init.ts:210` dispatch-table
+  gate fires before the schema layer, ai-native-rag not yet registered). Verified
+  live (rc=2). The exit-3 `selectScaffoldableVersion`-null path is downstream,
+  active once B.7.2 registers the archetype (Q-005). L2 fixture in `b7-1.test.sh`
+  (`--level 2`, opt-in `FORGE_B7_1_LIVE`, skip-pass if CLI not built). [Story:
   NFR-B7-1-002]
 - [x] **T3.3** Register `b7-1.test.sh` in `.github/workflows/forge-ci.yml` test
   matrix (after the prior B.7 entry / per array order). [Story: NFR-B7-1-004]

--- a/.forge/changes/b7-1-schema/tasks.md
+++ b/.forge/changes/b7-1-schema/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: b7-1-schema
 
-<!-- Status: implemented -->
+<!-- Status: archived -->
 <!-- Schema: default -->
 <!-- Audit: B.7.1 (docs/new-archetypes-plan.md §6.2 — ai-native-rag/1.0.0 archetype scaffold schema) -->
 
@@ -77,9 +77,10 @@ Constitution gate run per task (results inline; none blocks).
 - [x] **T4.3** REFACTOR: tidy header comments / section anchors; re-run the full
   `b7-1.test.sh` + `validate-foundations.sh` → still GREEN. [Gate: behavior
   unchanged]
-- [ ] **T4.4** `/forge:review b7-1-schema` — **independent code-reviewer APPROVE +
-  maintainer ratification** of ADR-B7-1-001..004 (Article V — not self-approved;
-  the design-phase resolutions are pending ratification per open-questions.md).
+- [x] **T4.4** `/forge:review b7-1-schema` — **independent code-reviewer APPROVE**
+  (2026-06-11, after one fix iteration on the HIGH exit-code finding) + **maintainer
+  ratification** of ADR-B7-1-001..004 + Q-005 (2026-06-11). Article V satisfied
+  (reviewer was a separate context). Archived.
 
 ## Constitution Gate (per task) — summary
 - TDD order enforced: harness RED (T1.2) precedes schema GREEN (T2.6). ✓

--- a/.forge/schemas/ai-native-rag/1.0.0.yaml
+++ b/.forge/schemas/ai-native-rag/1.0.0.yaml
@@ -1,0 +1,176 @@
+# Forge Schema — ai-native-rag 1.0.0 (CANDIDATE)
+# <!-- Audit: B.7.1 (b7-1-schema) — AI-native RAG archetype scaffold schema -->
+#
+# The AI-first RAG archetype (plan §6.2 B.7): a Rust backend (RAG pipeline +
+# in-repo LLM gateway proxy + MCP servers) + Qwik streaming UI + Postgres/pgvector
+# + Temporal + Zitadel + SigNoz/OBI/Coroot. It is the shared contract that the
+# rest of the B.7 chain (standards, scaffolder, Pythia, compliance, example,
+# harness) validates against.
+#
+# Stage semantics (THIS file):
+#   - candidate + scaffoldable:false : there are NO templates yet (B.7.2). The
+#     b8-3b validator enforces candidate⇒scaffoldable:false; the CLI
+#     `selectScaffoldableVersion` returns null for this archetype, so
+#     `forge init --archetype ai-native-rag` refuses cleanly (exit 3) rather than
+#     emitting a broken scaffold. Promotion to `stable` + `scaffoldable:true`
+#     happens in the B.7 scaffolder-completion brick, gated on a green b7-6
+#     harness (ADR-B7-1-002, mirroring the B.8.14-C2 flip). Additive: no existing
+#     archetype is affected.
+#
+# `extends: ai-first` below is DOCUMENTARY PROVENANCE ONLY. No scaffold-schema
+# loader resolves `extends` (parseSchemaMeta + check_versioned_schema_siblings
+# read this file's own fields). The AI-First phases are therefore MATERIALISED
+# INLINE in `phases:` (ADR-B7-1-001), extended with the two B.7.1 phases
+# `embeddings-pipeline` and `prompt-audit`.
+#
+# Component references (ADR-B7-1-003): no inline version pins. Each component
+# with an existing standard cites it; `llm-gateway` / `mcp-servers` /
+# `rag-pipeline` have NO standard yet (delivered_by B.7.3) and carry no pin
+# (the rmcp / pgvector-crate verify-then-pin candidates are NOT committed here).
+
+name: ai-native-rag
+version: "1.0.0"
+stage: candidate
+scaffoldable: false
+extends: ai-first            # documentary provenance only — NOT loader-resolved (ADR-B7-1-001)
+
+description: >
+  AI-first RAG archetype: Rust backend (RAG pipeline + in-repo LLM gateway proxy +
+  MCP servers via rmcp) + Qwik streaming UI + Postgres/pgvector (HNSW) + Temporal +
+  Zitadel + SigNoz/OBI/Coroot. Protos as single source of truth. TDD + BDD
+  enforced per layer; multi-layer changes routed by Janus. Mandatory AI fallback
+  (Article XI.5); PII-guarded (XI.6); prompt-audit + token budget traced (IX.6).
+  Not scaffoldable until B.7.2 ships templates.
+
+tdd_enforced: true
+bdd_required_for_user_facing: true
+coverage_threshold: 80
+ai_fallback_required: true   # Article XI.5 — every AI feature has a non-AI fallback
+
+# ─── Component SET (reference-only, ADR-B7-1-003) ─────────────────
+#
+# Each entry: name + role + (standard | delivered_by). NO inline version pin —
+# the standard yaml is the single source of truth. The three deferred components
+# (llm-gateway / mcp-servers / rag-pipeline) have no standard yet; B.7.3 ships
+# llm-gateway.md / mcp-servers.md / rag-patterns.md.
+components:
+  - name: pgvector
+    role: persistence
+    standard: persistence.yaml      # postgres-17 + pgvector (shared with flagship B.8.5)
+  - name: temporal
+    role: orchestration
+    standard: orchestration.yaml    # default_by_language.rust: temporal (§VIII.2, B8O)
+  - name: zitadel
+    role: identity
+    standard: identity.yaml
+  - name: connect-rpc
+    role: transport
+    standard: transport.yaml
+  - name: qwik-streaming
+    role: web-public
+    standard: web-frontend.yaml     # Qwik (B.8.9)
+  - name: observability
+    role: observability
+    standard: observability.yaml    # SigNoz/OBI/Coroot (B.8.8)
+  - name: llm-gateway
+    role: ai-inference
+    delivered_by: B.7.3             # in-repo Rust axum proxy (Mistral-EU/vLLM); standard NOT YET
+  - name: mcp-servers
+    role: tooling
+    delivered_by: B.7.3             # rmcp servers (db/file/search); standard NOT YET
+  - name: rag-pipeline
+    role: retrieval
+    delivered_by: B.7.3             # chunking/embeddings/retrieval/re-ranking; standard NOT YET
+
+# ─── Layers ───────────────────────────────────────────────────────
+# Required triple backend/frontend/infra (b8-3b validator). The Qwik streaming UI
+# is a frontend.surfaces entry (ADR-B7-1-004), mirroring full-stack 2.0.0
+# web-public — not a new top-level layer.
+layers:
+  - id: backend
+    path: backend/
+    fr_id_prefix: FR-BE-
+    primary_agent: Vulcan
+    standards_scope: [rust, all]
+  - id: frontend
+    path: frontend/
+    fr_id_prefix: FR-FE-
+    primary_agent: Hera
+    standards_scope: [flutter, all]
+    surfaces:
+      - id: web-public
+        path: web-public/
+        stack: qwik
+        note: Qwik streaming UI (SSE / WebTransport) — B.7.10
+  - id: infra
+    path: infra/
+    fr_id_prefix: FR-IN-
+    primary_agent: Atlas
+    standards_scope: [infra, all]
+
+fr_id_prefix_cross_layer: FR-GL-
+
+# ─── Cross-layer orchestration ───────────────────────────────────
+cross_layer:
+  agent: Janus
+  triggers:
+    - layers_count_ge: 2
+
+# ─── Phases (INLINED — ADR-B7-1-001) ─────────────────────────────
+# AI-First flow materialised from ai-first/schema.yaml, extended with the two
+# B.7.1 phases: embeddings-pipeline (specs the pipeline before design) and
+# prompt-audit (gate on prompt-audit logging, wiring Article IX.6).
+phases:
+  - id: ai_brainstorm
+    agent: Oracle
+    artifact: [ai-capability-map.md, agent-architecture.md, risk-matrix.md]
+    gate: fallback_strategy_defined
+    next: proposal
+  - id: proposal
+    artifact: proposal.md
+    gate: constitution_compliance
+    next: specs
+  - id: specs
+    artifact: specs.md
+    agent: Clio
+    gate: anti_hallucination_check
+    next: embeddings-pipeline
+  - id: embeddings-pipeline          # B.7.1 addition (§6.2)
+    artifact: embeddings-pipeline.md
+    gate: pipeline_specified
+    next: features
+  - id: features
+    artifact: "features/*.feature"
+    includes: [happy_path_with_ai, fallback_scenarios, error_scenarios]
+    next: design
+  - id: design
+    artifact: design.md
+    agent: [Athena, Prometheus]
+    gate: constitution_compliance
+    next: prompt-audit
+  - id: prompt-audit                 # B.7.1 addition (§6.2) — wires Article IX.6
+    artifact: prompt-audit.md
+    gate: prompt_audit_logging_defined
+    next: tasks
+  - id: tasks
+    artifact: tasks.md
+    gate: per_task_constitution_check
+    next: implementation
+  - id: implementation
+    protocol: tdd_cycle
+    agent: [Hera, Vulcan, Prometheus]
+    next: review
+  - id: review
+    agent: [Nemesis, Tribune, Aegis, Prometheus]
+    checks: [coverage, fallback_verified, pii_audit, token_budget]
+    next: archive
+  - id: archive
+
+# ─── AI specifics (carried from ai-first — XI.5/XI.6, IX.6) ──────
+ai_specifics:
+  fallback_mandatory: true
+  pii_handling: explicit_consent_required
+  token_budget_documented: true
+  non_determinism_testing:
+    strategy: snapshot + property_based
+    acceptable_variance: defined_per_feature

--- a/.forge/scripts/tests/b7-1.test.sh
+++ b/.forge/scripts/tests/b7-1.test.sh
@@ -22,9 +22,10 @@
 #   T-016  deferred components {llm-gateway,mcp-servers,rag-pipeline} carry delivered_by:B.7.3, no standard ref (FR-B7-1-032, ADR-B7-1-003)
 #   T-017  ai_fallback_required True + cross_layer.agent Janus + fr_id_prefix_cross_layer FR-GL- (FR-B7-1-013/024)
 #
-#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 3 refusal (FORGE_B7_1_LIVE=1 + built CLI; skip-pass otherwise)
+#   T-018  header block documents candidate semantics (candidate/scaffoldable/additive) (FR-B7-1-005)
+#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 2 unknown-archetype refusal (dispatch-table gate; FORGE_B7_1_LIVE=1 + built CLI; skip-pass otherwise)
 #
-# 17 L1 + 1 L2 tests. Performance budget: L1 ≤ 5 s, zero net/Docker. Structural
+# 18 L1 + 1 L2 tests. Performance budget: L1 ≤ 5 s, zero net/Docker. Structural
 # invariants (name==dir, version==file, layer triple, candidate=>scaffoldable:false,
 # phases non-empty) are ALSO enforced generically by validate-foundations.sh
 # check_versioned_schema_siblings (B.8.3.b); this harness adds the AI-specific
@@ -254,7 +255,7 @@ _test_b71_l1_009_qwik_web_public_surface() {
 
 _test_b71_l1_010_components_have_name() {
   _ensure_py_cache || return 1
-  [ "$(_get comp_missing_name)" != "True" ] || { echo "    FAIL T-010: a component lacks 'name' (FR-B7-1-030)" >&2; return 1; }
+  [ "$(_get comp_missing_name)" = "False" ] || { echo "    FAIL T-010: a component lacks 'name' (or comp_missing_name key absent) (FR-B7-1-030)" >&2; return 1; }
   local n; n=$(_get comp_count)
   { [ -n "$n" ] && [ "$n" != "0" ]; } || { echo "    FAIL T-010: components[] empty/absent (count='$n') (FR-B7-1-030)" >&2; return 1; }
 }
@@ -311,14 +312,33 @@ _test_b71_l1_017_ai_flags_and_cross_layer() {
   [ "$ok" = "1" ]
 }
 
+_test_b71_l1_018_header_block() {
+  # FR-B7-1-005: the documentary header comment block (lines before `name:`) MUST
+  # state candidate semantics, the promotion trigger, and additivity. Grep the
+  # header region only (not the YAML body, where `stage: candidate` would give a
+  # false pass). Fails loud if the file is missing (awk yields empty).
+  local header; header=$(awk '/^[^#]/{exit} {print}' "$SCHEMA" 2>/dev/null)
+  local ok=1
+  printf '%s' "$header" | grep -qiE 'candidate'  || { echo "    FAIL T-018: header block missing 'candidate' semantics (FR-B7-1-005)" >&2; ok=0; }
+  printf '%s' "$header" | grep -qiE 'promotion'  || { echo "    FAIL T-018: header block missing promotion trigger (FR-B7-1-005)" >&2; ok=0; }
+  printf '%s' "$header" | grep -qiE 'additive'   || { echo "    FAIL T-018: header block missing additivity note (FR-B7-1-005)" >&2; ok=0; }
+  [ "$ok" = "1" ]
+}
+
 # ─── L2 tests (opt-in live) ───────────────────────────────────────────────────
 
 _test_b71_l2_001_init_refuses() {
-  # The refusal contract: ai-native-rag has only a candidate/scaffoldable:false
-  # schema, so selectScaffoldableVersion (cli/src/domain/schema-version.ts) returns
-  # null ⇒ `forge init --archetype ai-native-rag` refuses with exit 3. That logic
-  # is unit-covered by schema-version.test.ts; this fixture exercises it end-to-end
-  # against the built CLI. Opt-in (FORGE_B7_1_LIVE=1) + requires cli/dist/index.js;
+  # The refusal contract (verified live against the built CLI, 2026-06-11):
+  # `forge init <name> --archetype ai-native-rag --org <rd>` exits **2**
+  # ("unknown archetype"). init.ts:210-216 checks the dispatch-table FIRST, and
+  # ai-native-rag is not registered in .forge/scaffolding/dispatch-table.yml, so
+  # the dispatch gate fires before the schema-version layer. The exit-3
+  # selectScaffoldableVersion-null guard (init.ts:232-238) is DOWNSTREAM and not
+  # reachable for this archetype yet; it becomes the active gate only once B.7.2
+  # registers ai-native-rag in the dispatch-table while the schema stays
+  # candidate/scaffoldable:false (update this assertion to exit 3 then — see
+  # open-questions.md Q-005). Either way init refuses cleanly with NO scaffold
+  # (NFR-B7-1-002). Opt-in (FORGE_B7_1_LIVE=1) + requires cli/dist/index.js;
   # skip-pass otherwise (mirrors b8-15 FORGE_B8_15_LIVE).
   local cli="$FORGE_ROOT/cli/dist/index.js"
   if [ "${FORGE_B7_1_LIVE:-0}" != "1" ] || [ ! -f "$cli" ]; then
@@ -327,10 +347,10 @@ _test_b71_l2_001_init_refuses() {
   fi
   local tmp; tmp=$(mk_tmpdir_with_trap b7-1-init)
   trap "rm -rf '$tmp'" RETURN
-  ( cd "$tmp" && node "$cli" init --archetype ai-native-rag >/dev/null 2>&1 )
+  ( cd "$tmp" && node "$cli" init testproj --archetype ai-native-rag --org com.example.test >/dev/null 2>&1 )
   local rc=$?
-  if [ "$rc" != "3" ]; then
-    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 3 (expected refusal — not scaffoldable)" >&2
+  if [ "$rc" != "2" ]; then
+    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 2 (expected clean refusal — unknown archetype; dispatch-table gate, init.ts:210)" >&2
     return 1
   fi
 }
@@ -356,6 +376,7 @@ main() {
   run_test _test_b71_l1_015_ai_specifics_present
   run_test _test_b71_l1_016_deferred_components
   run_test _test_b71_l1_017_ai_flags_and_cross_layer
+  run_test _test_b71_l1_018_header_block
   case "$LEVEL" in
     *2*) run_test _test_b71_l2_001_init_refuses ;;
   esac

--- a/.forge/scripts/tests/b7-1.test.sh
+++ b/.forge/scripts/tests/b7-1.test.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# Forge — B.7.1 ai-native-rag 1.0.0 candidate schema harness
+# <!-- Audit: B.7.1 (b7-1-schema) — ai-native-rag/1.0.0 archetype scaffold schema gate -->
+#
+# Validates the b7-1-schema deliverable .forge/schemas/ai-native-rag/1.0.0.yaml:
+#
+#   T-001  1.0.0.yaml exists at the versioned path (FR-B7-1-001/002)
+#   T-002  file parses as valid YAML mapping root (FR-B7-1-001)
+#   T-003  name == 'ai-native-rag' (FR-B7-1-002 + b8-3b name==dir invariant)
+#   T-004  version == '1.0.0' (FR-B7-1-002 + b8-3b filename<->version invariant)
+#   T-005  stage == 'candidate' (FR-B7-1-002)
+#   T-006  scaffoldable is False (FR-B7-1-003 + b8-3b candidate=>scaffoldable:false)
+#   T-007  tdd_enforced/bdd_required_for_user_facing/coverage_threshold (FR-B7-1-004)
+#   T-008  layers[] ids ⊇ {backend, frontend, infra} (FR-B7-1-010)
+#   T-009  frontend layer has a qwik web-public surface (FR-B7-1-011/012, ADR-B7-1-004)
+#   T-010  every components[] entry has a name; components non-empty (FR-B7-1-030)
+#   T-011  existing standard: refs resolve to real files (FR-B7-1-031)
+#   T-012  no component carries a forbidden inline pin key {version,pin,image} (FR-B7-1-031)
+#   T-013  no components[] scalar value matches \d+\.\d+ (no inline pin crept in) (FR-B7-1-032)
+#   T-014  phases inline & include ai_brainstorm + embeddings-pipeline + prompt-audit (FR-B7-1-020..023, ADR-B7-1-001)
+#   T-015  ai_specifics present (fallback_mandatory, pii_handling, token_budget_documented) (FR-B7-1-024)
+#   T-016  deferred components {llm-gateway,mcp-servers,rag-pipeline} carry delivered_by:B.7.3, no standard ref (FR-B7-1-032, ADR-B7-1-003)
+#   T-017  ai_fallback_required True + cross_layer.agent Janus + fr_id_prefix_cross_layer FR-GL- (FR-B7-1-013/024)
+#
+#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 3 refusal (FORGE_B7_1_LIVE=1 + built CLI; skip-pass otherwise)
+#
+# 17 L1 + 1 L2 tests. Performance budget: L1 ≤ 5 s, zero net/Docker. Structural
+# invariants (name==dir, version==file, layer triple, candidate=>scaffoldable:false,
+# phases non-empty) are ALSO enforced generically by validate-foundations.sh
+# check_versioned_schema_siblings (B.8.3.b); this harness adds the AI-specific
+# content asserts that the generic validator does not cover.
+
+set -uo pipefail
+
+LEVEL="1"
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--level" ]; then LEVEL="$arg"; fi
+  case "$arg" in --level=*) LEVEL="${arg#*=}" ;; esac
+  prev="$arg"
+done
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$HARNESS_DIR/.." && pwd)"
+FORGE_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+SCHEMA="$FORGE_ROOT/.forge/schemas/ai-native-rag/1.0.0.yaml"
+STANDARDS_DIR="$FORGE_ROOT/.forge/standards"
+
+# shellcheck source=./_helpers.sh
+source "$HARNESS_DIR/_helpers.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+# ─── Shared YAML parse helper (single python3 call, cached) ───────────────────
+_py() {
+  python3 - "$SCHEMA" "$STANDARDS_DIR" <<'PYEOF'
+import sys, yaml, re, os
+
+schema_path = sys.argv[1]
+std_dir     = sys.argv[2]
+
+try:
+    with open(schema_path, 'r', encoding='utf-8') as f:
+        d = yaml.safe_load(f)
+except FileNotFoundError:
+    print("MISSING"); sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"YAML_ERROR:{e}"); sys.exit(0)
+
+if not isinstance(d, dict):
+    print("NOT_MAPPING"); sys.exit(0)
+
+r = {}
+
+# identity
+r['name']    = d.get('name', 'MISSING')
+r['version'] = d.get('version', 'MISSING')
+r['stage']   = d.get('stage', 'MISSING')
+r['scaffoldable'] = repr(d.get('scaffoldable', 'MISSING'))
+
+# tdd/bdd/coverage + ai flags
+r['tdd_enforced']                   = repr(d.get('tdd_enforced', 'MISSING'))
+r['bdd_required_for_user_facing']   = repr(d.get('bdd_required_for_user_facing', 'MISSING'))
+r['coverage_threshold']             = repr(d.get('coverage_threshold', 'MISSING'))
+r['ai_fallback_required']           = repr(d.get('ai_fallback_required', 'MISSING'))
+
+# layers
+layers = d.get('layers', []) or []
+layer_ids = {l['id'] for l in layers if isinstance(l, dict) and 'id' in l}
+r['layer_ids'] = ','.join(sorted(layer_ids))
+
+# frontend surfaces (qwik web-public)
+fe = next((l for l in layers if isinstance(l, dict) and l.get('id') == 'frontend'), None)
+if fe:
+    surfaces = fe.get('surfaces', []) or []
+    qwik_pub = any(
+        isinstance(s, dict) and s.get('id') == 'web-public' and s.get('stack') == 'qwik'
+        for s in surfaces
+    )
+    r['qwik_web_public'] = repr(qwik_pub)
+else:
+    r['qwik_web_public'] = 'NO_FRONTEND'
+
+# components
+components = d.get('components', []) or []
+comp_names = [c.get('name', 'MISSING') for c in components if isinstance(c, dict)]
+r['comp_count'] = str(len(comp_names))
+r['comp_missing_name'] = str(any(n == 'MISSING' for n in comp_names))
+
+# existing standard refs resolve
+bad_refs = []
+for c in components:
+    if not isinstance(c, dict): continue
+    ref = c.get('standard')
+    if ref and not os.path.isfile(os.path.join(std_dir, ref)):
+        bad_refs.append(ref)
+r['bad_standard_refs'] = ','.join(bad_refs) if bad_refs else 'OK'
+
+# forbidden inline pin keys
+forbidden = {'version', 'pin', 'image'}
+pin_viol = []
+for c in components:
+    if not isinstance(c, dict): continue
+    hit = set(c.keys()) & forbidden
+    if hit:
+        pin_viol.append(f"{c.get('name','?')}:{','.join(sorted(hit))}")
+r['pin_violations'] = ';'.join(pin_viol) if pin_viol else 'OK'
+
+# no scalar value at components[] level matches ^\d+\.\d+ (value-walk, not grep)
+vre = re.compile(r'^\d+\.\d+')
+val_viol = []
+for c in components:
+    if not isinstance(c, dict): continue
+    for k, v in c.items():
+        if isinstance(v, str) and vre.match(v):
+            val_viol.append(f"{c.get('name','?')}.{k}={v!r}")
+r['val_violations'] = ';'.join(val_viol) if val_viol else 'OK'
+
+# phases inline & include the AI-First + B.7.1 ids
+phases = d.get('phases', []) or []
+phase_ids = {p['id'] for p in phases if isinstance(p, dict) and 'id' in p}
+r['phase_count'] = str(len(phases))
+for need in ('ai_brainstorm', 'embeddings-pipeline', 'prompt-audit'):
+    r[f'phase_{need}'] = str(need in phase_ids)
+
+# ai_specifics
+ais = d.get('ai_specifics', {}) or {}
+r['ais_fallback']   = repr(ais.get('fallback_mandatory', 'MISSING'))
+r['ais_pii']        = repr(ais.get('pii_handling', 'MISSING'))
+r['ais_token']      = repr(ais.get('token_budget_documented', 'MISSING'))
+
+# deferred components carry delivered_by:B.7.3 and no standard ref
+deferred = {'llm-gateway', 'mcp-servers', 'rag-pipeline'}
+bad_def = []
+seen_def = set()
+for c in components:
+    if not isinstance(c, dict): continue
+    nm = c.get('name')
+    if nm in deferred:
+        seen_def.add(nm)
+        if c.get('delivered_by') != 'B.7.3':
+            bad_def.append(f"{nm}:delivered_by={c.get('delivered_by')!r}")
+        if 'standard' in c:
+            bad_def.append(f"{nm}:has-standard-ref")
+missing_def = deferred - seen_def
+if missing_def:
+    bad_def.append("missing:" + ','.join(sorted(missing_def)))
+r['deferred_check'] = ';'.join(bad_def) if bad_def else 'OK'
+
+# cross-layer parity
+cl = d.get('cross_layer', {}) or {}
+r['cross_layer_agent'] = cl.get('agent', 'MISSING') if isinstance(cl, dict) else 'NOT_MAPPING'
+r['fr_cross'] = d.get('fr_id_prefix_cross_layer', 'MISSING')
+
+for k, v in r.items():
+    print(f"{k}={v}")
+PYEOF
+}
+
+_PY_OUT=""
+_ensure_py_cache() {
+  if [ -z "$_PY_OUT" ]; then
+    _PY_OUT=$(_py 2>&1) || { echo "    python3 helper failed: $_PY_OUT" >&2; return 1; }
+  fi
+}
+_get() { echo "$_PY_OUT" | grep "^${1}=" | head -1 | cut -d= -f2-; }
+
+# ─── L1 tests ────────────────────────────────────────────────────────────────
+
+_test_b71_l1_001_schema_exists() {
+  if [ ! -f "$SCHEMA" ]; then
+    echo "    FAIL T-001: 1.0.0.yaml missing: $SCHEMA (FR-B7-1-001/002)" >&2; return 1
+  fi
+}
+
+_test_b71_l1_002_valid_yaml_mapping() {
+  local out; out=$(_py 2>&1) || { echo "    FAIL T-002: _py helper error: $out" >&2; return 1; }
+  case "$(echo "$out" | head -1)" in
+    MISSING)     echo "    FAIL T-002: schema missing (should be caught by T-001)" >&2; return 1 ;;
+    YAML_ERROR*) echo "    FAIL T-002: YAML parse error" >&2; return 1 ;;
+    NOT_MAPPING) echo "    FAIL T-002: root is not a YAML mapping" >&2; return 1 ;;
+  esac
+}
+
+_test_b71_l1_003_name() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get name)
+  [ "$v" = "ai-native-rag" ] || { echo "    FAIL T-003: name='$v' != 'ai-native-rag' (FR-B7-1-002)" >&2; return 1; }
+}
+
+_test_b71_l1_004_version() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get version)
+  [ "$v" = "1.0.0" ] || { echo "    FAIL T-004: version='$v' != '1.0.0' (FR-B7-1-002)" >&2; return 1; }
+}
+
+_test_b71_l1_005_stage() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get stage)
+  [ "$v" = "candidate" ] || { echo "    FAIL T-005: stage='$v' != 'candidate' (FR-B7-1-002)" >&2; return 1; }
+}
+
+_test_b71_l1_006_scaffoldable_false() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get scaffoldable)
+  [ "$v" = "False" ] || { echo "    FAIL T-006: scaffoldable=$v != False (FR-B7-1-003; b8-3b candidate⇒scaffoldable:false)" >&2; return 1; }
+}
+
+_test_b71_l1_007_tdd_bdd_coverage() {
+  _ensure_py_cache || return 1
+  local ok=1
+  [ "$(_get tdd_enforced)" = "True" ] || { echo "    FAIL T-007: tdd_enforced != True (FR-B7-1-004)" >&2; ok=0; }
+  [ "$(_get bdd_required_for_user_facing)" = "True" ] || { echo "    FAIL T-007: bdd_required_for_user_facing != True (FR-B7-1-004)" >&2; ok=0; }
+  [ "$(_get coverage_threshold)" = "80" ] || { echo "    FAIL T-007: coverage_threshold != 80 (FR-B7-1-004)" >&2; ok=0; }
+  [ "$ok" = "1" ]
+}
+
+_test_b71_l1_008_layer_triple() {
+  _ensure_py_cache || return 1
+  local ids; ids=$(_get layer_ids); local ok=1
+  case "$ids" in *backend*)  ;; *) echo "    FAIL T-008: 'backend' missing (ids=$ids) (FR-B7-1-010)" >&2; ok=0 ;; esac
+  case "$ids" in *frontend*) ;; *) echo "    FAIL T-008: 'frontend' missing (FR-B7-1-010)" >&2; ok=0 ;; esac
+  case "$ids" in *infra*)    ;; *) echo "    FAIL T-008: 'infra' missing (FR-B7-1-010)" >&2; ok=0 ;; esac
+  [ "$ok" = "1" ]
+}
+
+_test_b71_l1_009_qwik_web_public_surface() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get qwik_web_public)
+  [ "$v" = "True" ] || { echo "    FAIL T-009: frontend has no qwik web-public surface (got $v) (FR-B7-1-011/012)" >&2; return 1; }
+}
+
+_test_b71_l1_010_components_have_name() {
+  _ensure_py_cache || return 1
+  [ "$(_get comp_missing_name)" != "True" ] || { echo "    FAIL T-010: a component lacks 'name' (FR-B7-1-030)" >&2; return 1; }
+  local n; n=$(_get comp_count)
+  { [ -n "$n" ] && [ "$n" != "0" ]; } || { echo "    FAIL T-010: components[] empty/absent (count='$n') (FR-B7-1-030)" >&2; return 1; }
+}
+
+_test_b71_l1_011_standard_refs_resolve() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get bad_standard_refs)
+  [ "$v" = "OK" ] || { echo "    FAIL T-011: standard: refs do not resolve: $v (FR-B7-1-031)" >&2; return 1; }
+}
+
+_test_b71_l1_012_no_forbidden_pin_keys() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get pin_violations)
+  [ "$v" = "OK" ] || { echo "    FAIL T-012: forbidden inline pin key(s) {version|pin|image}: $v (FR-B7-1-031)" >&2; return 1; }
+}
+
+_test_b71_l1_013_no_inline_version_values() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get val_violations)
+  [ "$v" = "OK" ] || { echo "    FAIL T-013: component scalar matches \\d+\\.\\d+ (inline pin crept in): $v (FR-B7-1-032)" >&2; return 1; }
+}
+
+_test_b71_l1_014_phases_inline_ai_first() {
+  _ensure_py_cache || return 1
+  [ "$(_get phase_count)" != "0" ] || { echo "    FAIL T-014: phases[] empty/absent — not inlined (ADR-B7-1-001)" >&2; return 1; }
+  local ok=1
+  [ "$(_get phase_ai_brainstorm)" = "True" ]      || { echo "    FAIL T-014: phase 'ai_brainstorm' missing (FR-B7-1-021)" >&2; ok=0; }
+  [ "$(_get 'phase_embeddings-pipeline')" = "True" ] || { echo "    FAIL T-014: phase 'embeddings-pipeline' missing (FR-B7-1-022)" >&2; ok=0; }
+  [ "$(_get 'phase_prompt-audit')" = "True" ]     || { echo "    FAIL T-014: phase 'prompt-audit' missing (FR-B7-1-023)" >&2; ok=0; }
+  [ "$ok" = "1" ]
+}
+
+_test_b71_l1_015_ai_specifics_present() {
+  _ensure_py_cache || return 1
+  local ok=1
+  [ "$(_get ais_fallback)" = "True" ] || { echo "    FAIL T-015: ai_specifics.fallback_mandatory != True (FR-B7-1-024, XI.5)" >&2; ok=0; }
+  [ "$(_get ais_pii)" = "'explicit_consent_required'" ] || { echo "    FAIL T-015: ai_specifics.pii_handling != explicit_consent_required (FR-B7-1-024, XI.6)" >&2; ok=0; }
+  [ "$(_get ais_token)" = "True" ] || { echo "    FAIL T-015: ai_specifics.token_budget_documented != True (FR-B7-1-024, IX.6)" >&2; ok=0; }
+  [ "$ok" = "1" ]
+}
+
+_test_b71_l1_016_deferred_components() {
+  _ensure_py_cache || return 1
+  local v; v=$(_get deferred_check)
+  [ "$v" = "OK" ] || { echo "    FAIL T-016: deferred components must carry delivered_by:B.7.3, no standard ref: $v (FR-B7-1-032, ADR-B7-1-003)" >&2; return 1; }
+}
+
+_test_b71_l1_017_ai_flags_and_cross_layer() {
+  _ensure_py_cache || return 1
+  local ok=1
+  [ "$(_get ai_fallback_required)" = "True" ] || { echo "    FAIL T-017: ai_fallback_required != True (FR-B7-1-024)" >&2; ok=0; }
+  [ "$(_get cross_layer_agent)" = "Janus" ] || { echo "    FAIL T-017: cross_layer.agent != Janus (FR-B7-1-013)" >&2; ok=0; }
+  [ "$(_get fr_cross)" = "FR-GL-" ] || { echo "    FAIL T-017: fr_id_prefix_cross_layer != FR-GL- (FR-B7-1-013)" >&2; ok=0; }
+  [ "$ok" = "1" ]
+}
+
+# ─── L2 tests (opt-in live) ───────────────────────────────────────────────────
+
+_test_b71_l2_001_init_refuses() {
+  # The refusal contract: ai-native-rag has only a candidate/scaffoldable:false
+  # schema, so selectScaffoldableVersion (cli/src/domain/schema-version.ts) returns
+  # null ⇒ `forge init --archetype ai-native-rag` refuses with exit 3. That logic
+  # is unit-covered by schema-version.test.ts; this fixture exercises it end-to-end
+  # against the built CLI. Opt-in (FORGE_B7_1_LIVE=1) + requires cli/dist/index.js;
+  # skip-pass otherwise (mirrors b8-15 FORGE_B8_15_LIVE).
+  local cli="$FORGE_ROOT/cli/dist/index.js"
+  if [ "${FORGE_B7_1_LIVE:-0}" != "1" ] || [ ! -f "$cli" ]; then
+    echo "    SKIP T-L2-001: set FORGE_B7_1_LIVE=1 with a built CLI (cli/dist/index.js) to run the live init-refusal check" >&2
+    return 0
+  fi
+  local tmp; tmp=$(mk_tmpdir_with_trap b7-1-init)
+  trap "rm -rf '$tmp'" RETURN
+  ( cd "$tmp" && node "$cli" init --archetype ai-native-rag >/dev/null 2>&1 )
+  local rc=$?
+  if [ "$rc" != "3" ]; then
+    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 3 (expected refusal — not scaffoldable)" >&2
+    return 1
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo "── B.7.1 — b7-1-schema — level $LEVEL ──"
+  run_test _test_b71_l1_001_schema_exists
+  run_test _test_b71_l1_002_valid_yaml_mapping
+  run_test _test_b71_l1_003_name
+  run_test _test_b71_l1_004_version
+  run_test _test_b71_l1_005_stage
+  run_test _test_b71_l1_006_scaffoldable_false
+  run_test _test_b71_l1_007_tdd_bdd_coverage
+  run_test _test_b71_l1_008_layer_triple
+  run_test _test_b71_l1_009_qwik_web_public_surface
+  run_test _test_b71_l1_010_components_have_name
+  run_test _test_b71_l1_011_standard_refs_resolve
+  run_test _test_b71_l1_012_no_forbidden_pin_keys
+  run_test _test_b71_l1_013_no_inline_version_values
+  run_test _test_b71_l1_014_phases_inline_ai_first
+  run_test _test_b71_l1_015_ai_specifics_present
+  run_test _test_b71_l1_016_deferred_components
+  run_test _test_b71_l1_017_ai_flags_and_cross_layer
+  case "$LEVEL" in
+    *2*) run_test _test_b71_l2_001_init_refuses ;;
+  esac
+  print_summary
+}
+
+main

--- a/.forge/specs/ai-native-rag.md
+++ b/.forge/specs/ai-native-rag.md
@@ -1,0 +1,115 @@
+# Spec: ai-native-rag
+
+<!-- Audit: B.7.1 (b7-1-schema) — ai-native-rag/1.0.0 archetype scaffold schema. -->
+<!-- This file accumulates the archived requirements for the ai-native-rag      -->
+<!-- archetype (plan §6.2, T7). Source change: `.forge/changes/b7-1-schema/`     -->
+<!-- (archived 2026-06-11). First brick of the B.7 chain; B.7.2 (scaffolder),    -->
+<!-- B.7.3 (standards), b7-pythia, etc. APPEND to this file as they archive.     -->
+
+**Namespace** : `FR-B7-1-*` / `NFR-B7-1-*` / `ADR-B7-1-*`.
+
+**Constitution** : v2.0.0 (no bump — additive; consumes §VIII.1 Envoy + §VIII.2
+Temporal as-is, materialises Article XI AI-First + IX.6 into the archetype process).
+
+**Position** : T7, first of the B.7 incremental chain
+(`.forge/_memory/b7-ai-native-rag-exploration.md`, ratified 2026-06-11). Ships the
+archetype scaffold schema only — no templates, no standards, no scaffolder, no
+version pins. The archetype is `stage: candidate` / `scaffoldable: false`:
+`forge init --archetype ai-native-rag` refuses cleanly (exit 2 — unknown
+archetype, dispatch-table-gated; B.7.2 registers it + flips the gate to exit 3).
+
+---
+
+## ADDED Requirements (b7-1-schema, archived 2026-06-11)
+
+Deliverable (built at impl): `.forge/schemas/ai-native-rag/1.0.0.yaml`, gated on
+landing by `validate-foundations.sh::check_versioned_schema_siblings` (b8-3b) and
+the dedicated harness `.forge/scripts/tests/b7-1.test.sh` (18 L1 + 1 L2, in
+`forge-ci.yml`).
+
+### Functional
+
+- **FR-B7-1-001** — archetype scaffold-schema shape (parity with
+  `full-stack-monorepo/2.0.0.yaml`): name/version/stage/scaffoldable/description/
+  tdd_enforced/bdd_required_for_user_facing/coverage_threshold/layers/
+  fr_id_prefix_cross_layer/cross_layer/phases. Not a bare workflow schema.
+- **FR-B7-1-002** — identity: `name: ai-native-rag`, `version: "1.0.0"`,
+  `stage: candidate`; file at the versioned path so the b8-3b filename↔version
+  invariant holds.
+- **FR-B7-1-003** — `scaffoldable: false` (b8-3b candidate⇒scaffoldable:false).
+- **FR-B7-1-004** — `tdd_enforced: true`, `bdd_required_for_user_facing: true`,
+  `coverage_threshold: 80`.
+- **FR-B7-1-005** — candidate header block documenting candidate semantics, the
+  promotion trigger, and additivity (tested by T-018).
+- **FR-B7-1-010** — `layers` ⊇ {backend, frontend, infra}, each id/path/
+  fr_id_prefix/primary_agent.
+- **FR-B7-1-011** — RAG layer roles: backend = Rust (RAG pipeline + in-repo LLM
+  gateway proxy + MCP servers, Vulcan); frontend = Qwik streaming UI; infra =
+  pgvector/Temporal/Zitadel/observability (Atlas).
+- **FR-B7-1-012** — Qwik streaming UI modelled under `frontend.surfaces` (full-stack
+  2.0.0 precedent), not a new top-level layer.
+- **FR-B7-1-013** — `fr_id_prefix_cross_layer: FR-GL-` + `cross_layer` routing
+  ≥2-layer changes to Janus.
+- **FR-B7-1-020** — `phases` authored inline (not via `extends`; no loader resolves
+  it).
+- **FR-B7-1-021** — inlined phases materialise the `ai-first` flow: `ai_brainstorm`
+  (Oracle, gate `fallback_strategy_defined`) → proposal → specs → … → archive.
+- **FR-B7-1-022** — `embeddings-pipeline` phase added (specs the
+  chunking/embeddings/retrieval/re-ranking pipeline before design).
+- **FR-B7-1-023** — `prompt-audit` gate added (prompt-audit logging; wires IX.6).
+- **FR-B7-1-024** — `ai_specifics`: `fallback_mandatory: true` (XI.5),
+  `pii_handling: explicit_consent_required` (XI.6), `token_budget_documented: true`,
+  `non_determinism_testing`; `ai_fallback_required: true` top-level.
+- **FR-B7-1-030** — declare the component SET by name (pgvector, llm-gateway,
+  mcp-servers, rag-pipeline, temporal, zitadel, connect-rpc, qwik, observability).
+- **FR-B7-1-031** — reference existing standards, no inline pins
+  (pgvector→persistence.yaml, temporal→orchestration.yaml, zitadel→identity.yaml,
+  connect→transport.yaml, qwik→web-frontend.yaml, observability→observability.yaml).
+- **FR-B7-1-032** — LLM gateway / MCP / RAG patterns reference the deferred B.7.3
+  standards (`delivered_by: B.7.3`), no inline pin, no fabricated standard filename
+  (Article III.4). `rmcp` / pgvector Rust crate verify-then-pin candidates NOT
+  committed here.
+
+### Non-Functional
+
+- **NFR-B7-1-001** — additive only; no existing schema/standard/constitution/CLI/
+  template edited (CI-matrix registration excepted).
+- **NFR-B7-1-002** — clean non-scaffoldable behaviour: `forge init --archetype
+  ai-native-rag` refuses with no scaffold. **Today exit 2** (unknown archetype,
+  `init.ts:210` dispatch-table gate, archetype unregistered); shifts to exit 3
+  (`selectScaffoldableVersion` null, `init.ts:232`) once B.7.2 registers it (Q-005).
+- **NFR-B7-1-003** — validators GREEN on landing: `validate-foundations.sh`
+  `FR-GL-001-versioned:ai-native-rag/1.0.0.yaml` PASS; verify.sh +
+  constitution-linter.sh no regression.
+- **NFR-B7-1-004** — dedicated harness `b7-1.test.sh` (18 L1 + 1 L2 opt-in
+  `FORGE_B7_1_LIVE` init-refusal), registered in `forge-ci.yml`.
+
+## ADRs (ratified — maintainer 2026-06-11; independent reviewer APPROVE)
+
+- **ADR-B7-1-001** — AI-First phases INLINED, not inherited via `extends` (no
+  scaffold-schema loader resolves `extends`; `extends: ai-first` kept as
+  documentary provenance). Resolves the §6.2 conflation.
+- **ADR-B7-1-002** — `candidate` + `scaffoldable: false`; promotion to
+  stable+scaffoldable deferred to the B.7 scaffolder-completion brick, gated on a
+  green b7-6 harness (B.8.14-C2 pattern).
+- **ADR-B7-1-003** — components reference-only; llm-gateway/mcp-servers/rag-patterns
+  referenced as `delivered_by: B.7.3`, gap recorded, no fabrication.
+- **ADR-B7-1-004** — backend/frontend/infra triple; Qwik streaming under
+  `frontend.surfaces`; primary_agents Vulcan/Hera/Atlas.
+
+## Open questions (resolved)
+
+- **Q-001..Q-004** resolved at design (ADR-B7-1-001..004).
+- **Q-005** (independent review, HIGH): `forge init` refusal is exit 2 (unknown
+  archetype) today, not exit 3 — `init.ts:210` dispatch-table gate fires before the
+  schema-version layer. Resolved: accept exit 2 for B.7.1; dispatch-table
+  registration + the exit-3 flip belong to B.7.2. Lesson (Article III.4): the
+  schema-version layer was verified in isolation; the full `init.ts` control flow
+  must be traced before claiming an integration outcome.
+
+## Downstream (this schema gates)
+
+B.7.2 (`b7-2-scaffolder` — registers ai-native-rag in dispatch-table.yml, ships
+templates + scaffold-plan, flips exit-2→exit-3 then stable+scaffoldable), B.7.3
+(`b7-standards` — llm-gateway/mcp-servers/rag-patterns), `b7-pythia` (K.2),
+`b7-9-janus-ai` (J.8.c), `b7-5-ai-act`, `b7-7-example`, `b7-6-harness`.

--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -120,6 +120,7 @@ jobs:
             "b8-15.test.sh --level 1"
             "b8-14-flip.test.sh --level 1"
             "b8o.test.sh --level 1"
+            "b7-1.test.sh --level 1,2"
           )
           fail=0
           for entry in "${harnesses[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ minor bump and will be called out under a `### BREAKING` subsection.
 
 ## [Unreleased]
 
+### Added
+
+- **`ai-native-rag` archetype scaffold schema (B.7.1, `b7-1-schema`)** — first
+  brick of the T7 AI-native RAG archetype chain (plan §6.2). Ships
+  `.forge/schemas/ai-native-rag/1.0.0.yaml` as `stage: candidate` /
+  `scaffoldable: false`: the archetype is declared but **not yet scaffoldable**, so
+  `forge init --archetype ai-native-rag` refuses cleanly (exit 2 — unknown
+  archetype, dispatch-table-gated until B.7.2). AI-First phases are materialised
+  inline (no scaffold-schema loader resolves `extends`) plus two B.7.1 phases —
+  `embeddings-pipeline` and `prompt-audit` (wiring Article XI.5/XI.6 + IX.6).
+  Components are reference-only (no inline pins); the LLM gateway / MCP servers /
+  RAG-patterns standards are deferred to B.7.3. Harness `b7-1.test.sh` (18 L1 + 1
+  L2) in `forge-ci.yml`; validated on landing by the b8-3b versioned-schema gate.
+  Additive — no existing schema/standard/constitution/CLI/template touched.
+  Independent reviewer APPROVE; ADRs ratified.
+
 ## [0.4.0] — 2026-06-06
 
 First **stable** cut of the 0.4.0 line. Headline: the **B.8 flagship migration is


### PR DESCRIPTION
## What

First brick of the **T7 `ai-native-rag` archetype chain** (plan §6.2). Ships the archetype scaffold schema `.forge/schemas/ai-native-rag/1.0.0.yaml` as `stage: candidate` / `scaffoldable: false` + its harness. Drove the full Forge pipeline: explore → propose → specify → design → plan → implement → review → archive.

## Key decisions (ADR-B7-1-001..004, ratified)

- **Phases inlined, not `extends`** — verified no scaffold-schema loader resolves `extends`; `extends: ai-first` kept as documentary provenance. AI-First flow materialised + `embeddings-pipeline` / `prompt-audit` phases added (wiring Article XI.5/XI.6 + IX.6).
- **`candidate` / `scaffoldable: false`** — `forge init --archetype ai-native-rag` refuses cleanly (**exit 2**, unknown archetype — dispatch-table-gated). Promotion + exit-3 flip + dispatch-table registration deferred to **B.7.2** (Q-005).
- **Components reference-only** — pgvector/temporal/zitadel/connect/qwik/observability cite existing standards; `llm-gateway`/`mcp-servers`/`rag-pipeline` deferred to **B.7.3** (no inline pins; `rmcp`/pgvector-crate verify-then-pin LIVE later). No fabrication (Article III.4).
- **Layers** backend/frontend/infra; Qwik streaming under `frontend.surfaces`.

## Review trail (Article V)

Independent reviewer caught a **HIGH** defect (init refusal was claimed exit-3 but is really **exit 2** — the `init.ts:210` dispatch-table gate fires before the schema-version layer). Fixed in `8c8e46d`, re-verified live, then **APPROVE**. ADRs ratified by maintainer. Lesson recorded in Q-005.

## Verification

- `b7-1.test.sh` **19/19** (18 L1 + 1 L2) — CI **and** live (`FORGE_B7_1_LIVE=1`, exit-2 asserted against the real CLI)
- `verify.sh` **423/0 PASS** · `constitution-linter.sh` **OVERALL PASS** · `validate-change-yaml.sh` exit 0
- Gated on landing by `check_versioned_schema_siblings` (b8-3b)

## Scope

Additive only — no existing schema/standard/constitution/CLI/template touched (CI-matrix registration of the harness excepted). Spec consolidated to `.forge/specs/ai-native-rag.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)