### PR TITLE
feat(b7-2a): register ai-native-rag, flip forge init refusal exit 2→3 (B.7.2)

### DIFF
--- a/.forge/changes/b7-2a-dispatch-register/.forge.yaml
+++ b/.forge/changes/b7-2a-dispatch-register/.forge.yaml
@@ -1,0 +1,16 @@
+name: b7-2a-dispatch-register
+status: implemented
+created: 2026-06-12
+schema: default
+constitution_version: "2.0.0"
+parent_audit_items:
+  - B.7.2  # docs/new-archetypes-plan.md §6.2 B.7.2 — first slice: dispatch-table registration + exit-2→exit-3 refusal flip (resolves Q-005)
+depends_on:
+  - B.7.1  # ships .forge/schemas/ai-native-rag/1.0.0.yaml (candidate/scaffoldable:false) — the schema this makes refusable via the schema-version layer
+  - B.8.14 # cli versioned-schema selection + B.8.3.b scaffoldable:false guard (resolveScaffolder → exit 3); generic readArchetypeSchemas (cli.ts:135)
+timeline:
+  proposed: 2026-06-12
+  specified: 2026-06-12
+  designed: 2026-06-12
+  planned: 2026-06-12
+  implemented: 2026-06-12

--- a/.forge/changes/b7-2a-dispatch-register/.forge.yaml
+++ b/.forge/changes/b7-2a-dispatch-register/.forge.yaml
@@ -1,5 +1,5 @@
 name: b7-2a-dispatch-register
-status: implemented
+status: archived
 created: 2026-06-12
 schema: default
 constitution_version: "2.0.0"
@@ -14,3 +14,4 @@ timeline:
   designed: 2026-06-12
   planned: 2026-06-12
   implemented: 2026-06-12
+  archived: 2026-06-12

--- a/.forge/changes/b7-2a-dispatch-register/design.md
+++ b/.forge/changes/b7-2a-dispatch-register/design.md
@@ -1,0 +1,116 @@
+# Design: b7-2a-dispatch-register
+
+<!-- Status: designed -->
+<!-- Schema: default -->
+<!-- Audit: B.7.2 (docs/new-archetypes-plan.md §6.2 — ai-native-rag dispatch registration slice) -->
+
+Resolves the proposal/specs ADRs + open questions. Additive slice of B.7.2 that
+flips the `forge init --archetype ai-native-rag` refusal from exit 2 (unknown
+archetype) to exit 3 (registered, no scaffoldable schema version) — Q-005.
+
+## Architecture Decisions
+
+### ADR-B7-2A-001 — refusing wrapper, not a `<pending>` sentinel
+**Context**: `b5.test.sh::test_dispatch_scaffolders_exist` requires every entry's
+`scaffolder` to be a real file (or `<built-in>`/`<removed>`/`status:
+removed_from_roadmap`). The dispatch-table ABI mandates a
+`bin/forge-init-<archetype>.sh` wrapper per entry.
+**Decision**: ship `bin/forge-init-ai-native-rag.sh` as a **refusing wrapper**
+(exit 3, no writes). It satisfies the scaffolder-exists gate with a real file,
+follows the documented entry+wrapper ABI, and is the wrapper-side defense-in-depth
+layer (mirroring `_refuse_if_forbidden`, J.8). B.7.2-full replaces its body with
+the real scaffold logic. The alternative — a `scaffolder: "<pending>"` sentinel +
+teaching `b5.test.sh` to skip it — is rejected: it edits an existing test and
+diverges from the ABI.
+**Consequences**: one new bash file; no b5.test.sh edit. The CLI's own
+`resolveScaffolder` refusal fires first, so the wrapper is belt-and-suspenders
+today (exercised only on direct invocation or CLI bypass).
+**Constitution**: Article IV (additive) + III.4 (the b5 gate re-read, not guessed).
+
+### ADR-B7-2A-002 — refusal exit code = 3
+**Context**: two refusal layers (CLI `resolveScaffolder`, wrapper). 
+**Decision**: both exit **3** — the B.8.3.b no-scaffoldable-version semantics and
+the J.8 policy-refusal convention (ADR-J8-003). Consistent regardless of which
+layer fires.
+**Consequences**: `forge init --archetype ai-native-rag` and a direct
+`bin/forge-init-ai-native-rag.sh` invocation both exit 3.
+
+### ADR-B7-2A-003 — wrapper: structured stderr, exit 3, zero writes
+**Decision**: the wrapper prints `[REFUSAL: ai-native-rag: not-yet-scaffoldable :
+candidate schema, templates ship in B.7.2 ; see .forge/specs/ai-native-rag.md]`
+to stderr and exits 3, performing **no** filesystem writes (never a partial
+scaffold). It accepts/ignores the standard wrapper args (project name, --org,
+--force) for ABI shape but acts on none.
+**Constitution**: XI fallback semantics N/A (no AI here); III.4 honest "not yet".
+
+### ADR-B7-2A-004 — `since: "0.5.0"` (Q-001 resolved)
+**Context**: `docs/VERSIONING.md:31` — "New archetypes are introduced" ⇒ **MINOR**
+bump on the 0.y track. b7-1-schema already moved `[Unreleased]` toward the next
+minor.
+**Decision**: `since: "0.5.0"`. Rejected: 0.4.1 (patch) — a user-visible new
+archetype is a minor, not a patch.
+
+### ADR-B7-2A-005 — documentary `status: candidate` (Q-002 resolved)
+**Decision**: the entry carries `status: candidate` (parser-tolerated;
+human signal that it is registered-but-not-scaffoldable). **No `b5.test.sh`
+change** — the wrapper file exists, so the scaffolder-exists gate passes on the
+path, independent of status. A b7-2a L1 test asserts the marker.
+
+## Component Design
+
+```mermaid
+graph TD
+  U["forge init --archetype ai-native-rag"]
+  G1["init.ts:210 dispatch-table gate"]
+  RS["resolveScaffolder (init-archetype.ts:128)"]
+  RAS["readArchetypeSchemas (cli.ts:135, generic)<br/>reads assets/.forge/schemas/ai-native-rag/*.yaml"]
+  W["bin/forge-init-ai-native-rag.sh (refusing wrapper)"]
+
+  U --> G1
+  G1 -->|"BEFORE: not registered ⇒ exit 2"| X2["exit 2 (was)"]
+  G1 -->|"AFTER: registered ⇒ pass"| RS
+  RS --> RAS
+  RAS -->|"metas=[1.0.0 candidate scaffoldable:false]<br/>selectScaffoldableVersion ⇒ null"| R3["refuse ⇒ exit 3 (now)"]
+  RS -.->|"scaffolder never invoked (refused first);<br/>direct call ⇒"| W
+  W -->|"structured stderr, no writes"| R3
+```
+
+## Data Flow
+
+After this change, `forge init testproj --archetype ai-native-rag --org com.example.test`:
+dispatch gate passes (registered) → `resolveScaffolder` → `readArchetypeSchemas`
+returns `[candidate/scaffoldable:false]` → `selectScaffoldableVersion` null →
+`{kind:"refuse"}` → **exit 3**. The wrapper is not invoked (refused upstream); a
+direct `bin/forge-init-ai-native-rag.sh` call independently exits 3.
+
+## Testing Strategy (TDD — Article I)
+
+1. **RED**: author `b7-2a.test.sh` (entry present/well-formed; wrapper
+   exists/executable/refuses exit 3 + no writes; opt-in L2 CLI exit-3). Run →
+   fails (no entry, no wrapper). Verify RED.
+2. **GREEN**: add the dispatch entry + the wrapper. Run b7-2a.test.sh → PASS.
+   Flip b7-1.test.sh L2 to exit 3; confirm `b5.test.sh` GREEN
+   (scaffolder-exists), `forge init` live → exit 3.
+3. **REFACTOR**: tidy; re-run; verify.sh + constitution-linter.sh no regression.
+- **Unit/L1**: hermetic grep + direct-wrapper-invocation asserts (no network).
+- **Integration/L2**: opt-in `FORGE_B7_2A_LIVE` + built CLI (bundles the schema +
+  dispatch entry into assets) → CLI exit 3; skip-pass otherwise.
+- **BDD**: N/A (tooling/config change, not a user-facing feature).
+- Register `b7-2a.test.sh` in `forge-ci.yml`.
+
+## Standards Applied
+
+- `global/scaffolding.md` — the wrapper ABI shape.
+- FR-IW-002 (b5-1-init-wizard) — dispatch entry schema + scaffolder-exists gate.
+- `docs/VERSIONING.md` — `since:` = MINOR (new archetype) ⇒ 0.5.0.
+- Article III.4 — refusal precedence, generic readArchetypeSchemas, and the b5
+  gate all re-read from live code.
+
+## Constitutional Compliance Gate
+
+- Article I (TDD): harness RED before entry/wrapper. ✓
+- Article IV (delta): additive; existing-file edits = dispatch append + b7-1 L2
+  flip (verified behaviour) + CI matrix. ✓
+- Article III.4: no fabrication; `since:` resolved via VERSIONING, not guessed. ✓
+- No Flutter/Rust arch articles engaged; no amendment (XII). ✓
+**Gate: PASS.**

--- a/.forge/changes/b7-2a-dispatch-register/design.md
+++ b/.forge/changes/b7-2a-dispatch-register/design.md
@@ -36,11 +36,14 @@ layer fires.
 `bin/forge-init-ai-native-rag.sh` invocation both exit 3.
 
 ### ADR-B7-2A-003 — wrapper: structured stderr, exit 3, zero writes
-**Decision**: the wrapper prints `[REFUSAL: ai-native-rag: not-yet-scaffoldable :
-candidate schema, templates ship in B.7.2 ; see .forge/specs/ai-native-rag.md]`
-to stderr and exits 3, performing **no** filesystem writes (never a partial
-scaffold). It accepts/ignores the standard wrapper args (project name, --org,
---force) for ABI shape but acts on none.
+**Decision**: the wrapper prints a `[REFUSAL: ai-native-rag: not-yet-scaffoldable:
+...]` line to stderr and exits 3, performing **no** filesystem writes (never a
+partial scaffold). The shipped message (`bin/forge-init-ai-native-rag.sh`) is:
+`[REFUSAL: ai-native-rag: not-yet-scaffoldable: the ai-native-rag schema is a
+candidate (scaffoldable:false) — templates ship in B.7.2 ; alternative: use
+--archetype full-stack-monorepo, or 'default' then add RAG components manually]`.
+The wrapper ignores all args (no parse loop, so `set -e` has no shift hazard);
+the harness greps `\[REFUSAL` only.
 **Constitution**: XI fallback semantics N/A (no AI here); III.4 honest "not yet".
 
 ### ADR-B7-2A-004 — `since: "0.5.0"` (Q-001 resolved)

--- a/.forge/changes/b7-2a-dispatch-register/open-questions.md
+++ b/.forge/changes/b7-2a-dispatch-register/open-questions.md
@@ -91,6 +91,24 @@ scaffold matrix (and assert their refusal instead), or exclude candidates from
   `init.snap.txt`; `archetypes-smoke.test.ts` partitions `status === "candidate"`.
   `cd cli && npm test` → 87 passed / 1 skipped. Keeps coverage on the new
   behaviour; the candidate rejoins the scaffold matrix at promotion (B.7.2).
+
+### Q-003 addendum — a THIRD coupled test surfaced in CI (2026-06-13)
+
+The fix above covered the two TS e2e tests, but CI then failed on a third,
+SHELL-side enumerator the local gate run had not exercised:
+`.forge/scripts/tests/t5-1.test.sh::_test_t51_l1_016_dispatch_xref` (FR-T51-055)
+— the bash mirror of the smoke fixture cross-reference. It required a fixture for
+every active archetype, excluding only `default`/`removed_from_roadmap`/`<removed>`,
+not `candidate`. Fixed identically: exclude `status: candidate` from the fixture
+requirement (both flush branches + the comment). Re-ran the **full** dispatch-coupled
+set live — `t5-1` 17/0, `b5` 17/0, `j8` 18/0, `b8-15` 9/0, `b7-2a` 3/0, `b7-1` 18/0,
+`cd cli && npm test` 87/1-skip — plus a repo-wide sweep for any other
+active-archetype enumerator (`init.test.ts` uses its own table + `"made-up"`;
+`b8-15` hardcodes the fsm fixture; `j8` is the forbidden list — all safe).
+**Reinforced lesson (III.4):** the coupling was THREE tests, not two; the
+ground-truth pass must grep every `FIXTURES_DIR` / active-archetype enumerator
+(shell AND TS), and the gate run must execute the full harness array, not a
+subset. B.7.2-full re-checks all three at promotion.
 - (b) Exclude candidates from "active" everywhere — rejected: it would hide the
   archetype from `--help` despite it being a real, registered choice, and lose the
   refusal assertion.

--- a/.forge/changes/b7-2a-dispatch-register/open-questions.md
+++ b/.forge/changes/b7-2a-dispatch-register/open-questions.md
@@ -8,6 +8,7 @@ Q-NNN sequential, never reused. Author-phase leanings recorded; resolutions at
 - **Q-001** resolved at /forge:design 2026-06-12 → (a) `since: "0.5.0"` (VERSIONING.md:31 — new archetypes ⇒ MINOR). ADR-B7-2A-004.
 - **Q-002** resolved at /forge:design 2026-06-12 → (a) documentary `status: candidate`, no b5.test.sh change. ADR-B7-2A-005.
 - Resolutions authored at design; independent reviewer + maintainer ratification pending at /forge:review (Article V).
+- **Q-003** raised + resolved at /forge:review 2026-06-12 → (a) candidate stays discoverable in --help + refusal-asserted in smoke; CLI help text/snapshot + archetypes-smoke partition fixed. `cd cli && npm test` 87 passed / 1 skipped.
 -->
 
 ## Q-001: `since:` value for the ai-native-rag dispatch entry
@@ -58,3 +59,44 @@ themselves?]`
   asserts the marker.
 - (b) Keep plain — the schema stage + the wrapper already encode the state.
   Avoids inventing a status enum value not used elsewhere.
+
+## Q-003: CLI e2e coupling of an active dispatch-table archetype
+
+- **Status**: answered → resolved (independent review HIGH/CRITICAL, fixed)
+- **Raised in**: independent review of commit 5525f05, 2026-06-12
+- **Raised by**: independent code-reviewer
+
+### Question
+
+Registering an **active** (`status !== removed_from_roadmap`) archetype couples to
+two pre-existing T5.1 CLI e2e tests that the first author pass missed:
+- `help-snapshots.test.ts` asserts every active archetype appears in `forge init
+  --help` (hardcoded text at `cli/src/cli.ts:77` + the `init.snap.txt` snapshot);
+- `archetypes-smoke.test.ts` treats every active archetype as scaffoldable —
+  requires a fixture (`ENOENT` crash otherwise) and asserts scaffold exit 0,
+  incompatible with the `candidate` archetype's exit-3 refusal.
+So `cd cli && npm test` would FAIL in CI even though `verify.sh`, the linter, and
+the shell harnesses are all green.
+
+`[NEEDS CLARIFICATION: keep candidates discoverable in --help but excluded from the
+scaffold matrix (and assert their refusal instead), or exclude candidates from
+"active" everywhere?]`
+
+- (a) **Discoverable + refusal-asserted** *(chosen)* — a candidate stays in
+  `--help` (it IS a known archetype) and is exercised by a NEW smoke test that
+  asserts exit 3 + no scaffold; it is partitioned OUT of the fixture/scaffold
+  matrix until promotion. Fixes: `cli/src/cli.ts:77` help text + regen
+  `init.snap.txt`; `archetypes-smoke.test.ts` partitions `status === "candidate"`.
+  `cd cli && npm test` → 87 passed / 1 skipped. Keeps coverage on the new
+  behaviour; the candidate rejoins the scaffold matrix at promotion (B.7.2).
+- (b) Exclude candidates from "active" everywhere — rejected: it would hide the
+  archetype from `--help` despite it being a real, registered choice, and lose the
+  refusal assertion.
+
+### Lesson (Article III.4)
+
+The proposal's ground-truth pass traced `init.ts`/`resolveScaffolder`/`b5.test.sh`
+but did NOT enumerate the e2e tests that cross-reference the dispatch table. The
+author's gate run also omitted `cd cli && npm test`. Both fixed; NFR-B7-2A-001
+blast-radius corrected. Recorded so B.7.2-full (promotion) re-checks the same
+e2e couplings when it flips the candidate to scaffoldable.

--- a/.forge/changes/b7-2a-dispatch-register/open-questions.md
+++ b/.forge/changes/b7-2a-dispatch-register/open-questions.md
@@ -1,0 +1,60 @@
+# Open Questions — b7-2a-dispatch-register
+
+<!--
+Q-NNN sequential, never reused. Author-phase leanings recorded; resolutions at
+/forge:design by an independent reviewer + maintainer (Article V).
+
+## Resolution log
+- **Q-001** resolved at /forge:design 2026-06-12 → (a) `since: "0.5.0"` (VERSIONING.md:31 — new archetypes ⇒ MINOR). ADR-B7-2A-004.
+- **Q-002** resolved at /forge:design 2026-06-12 → (a) documentary `status: candidate`, no b5.test.sh change. ADR-B7-2A-005.
+- Resolutions authored at design; independent reviewer + maintainer ratification pending at /forge:review (Article V).
+-->
+
+## Q-001: `since:` value for the ai-native-rag dispatch entry
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-12)
+- **Raised in**: proposal.md (Ground truth), specs.md FR-B7-2A-001
+- **Raised on**: 2026-06-12
+
+### Question
+
+The dispatch `since:` field is the framework version that registered the
+archetype. The framework is at 0.4.0 (released); this change lands in
+`[Unreleased]`. Is the next cut 0.5.0 (minor — a new archetype is a feature) or
+0.4.1 (patch)?
+
+`[NEEDS CLARIFICATION: confirm against docs/VERSIONING.md whether registering a
+new (non-scaffoldable) archetype is a minor (0.5.0) or patch (0.4.1) on the 0.y
+pre-GA track.]`
+
+- (a) **`since: "0.5.0"`** *(leaning)* — a new archetype is an additive feature;
+  minor bump on the 0.y track. Most consistent with full-stack (1.0.0) /
+  mobile-only (1.2.0) being feature-introducing versions.
+- (b) `since: "0.4.1"` — treat a not-yet-scaffoldable registration as a patch.
+  Weaker: it still adds a user-visible archetype to `forge init`.
+
+Resolve by reading `docs/VERSIONING.md` at design; non-blocking for the logic.
+
+## Q-002: does the entry carry a `status:` marker?
+
+- **Status**: answered → option (a) (ADR finalized at /forge:design 2026-06-12)
+- **Raised in**: proposal.md (Solution step 1), specs.md FR-B7-2A-001
+- **Raised on**: 2026-06-12
+
+### Question
+
+`mobile-only` carries `status: legacy_alias`; `flutter-firebase` carries
+`status: removed_from_roadmap`. Should ai-native-rag carry a documentary
+`status:` (e.g. `candidate` / `not_scaffoldable`) for human clarity?
+
+`[NEEDS CLARIFICATION: add a documentary status: marker, or keep the entry plain
+and let the candidate/scaffoldable:false schema + the refusing wrapper speak for
+themselves?]`
+
+- (a) **Add `status: candidate`** *(leaning)* — cheap human signal that the
+  archetype is registered-but-not-scaffoldable. The dispatch parser tolerates
+  `status`. **No `b5.test.sh` change needed** (the wrapper file exists, so the
+  scaffolder-exists gate passes regardless of status). If chosen, a b7-2a L1 test
+  asserts the marker.
+- (b) Keep plain — the schema stage + the wrapper already encode the state.
+  Avoids inventing a status enum value not used elsewhere.

--- a/.forge/changes/b7-2a-dispatch-register/open-questions.md
+++ b/.forge/changes/b7-2a-dispatch-register/open-questions.md
@@ -9,6 +9,8 @@ Q-NNN sequential, never reused. Author-phase leanings recorded; resolutions at
 - **Q-002** resolved at /forge:design 2026-06-12 → (a) documentary `status: candidate`, no b5.test.sh change. ADR-B7-2A-005.
 - Resolutions authored at design; independent reviewer + maintainer ratification pending at /forge:review (Article V).
 - **Q-003** raised + resolved at /forge:review 2026-06-12 → (a) candidate stays discoverable in --help + refusal-asserted in smoke; CLI help text/snapshot + archetypes-smoke partition fixed. `cd cli && npm test` 87 passed / 1 skipped.
+- Independent code-reviewer verdict: **APPROVE** (2026-06-12, after one fix iteration on the CRITICAL/HIGH CLI-e2e regression).
+- **MAINTAINER RATIFICATION 2026-06-12**: BDFL ratified ADR-B7-2A-001..005 + Q-001/Q-002/Q-003. All decisions final. Cleared for archive.
 -->
 
 ## Q-001: `since:` value for the ai-native-rag dispatch entry

--- a/.forge/changes/b7-2a-dispatch-register/proposal.md
+++ b/.forge/changes/b7-2a-dispatch-register/proposal.md
@@ -1,0 +1,146 @@
+# Proposal: b7-2a-dispatch-register
+
+<!-- Created: 2026-06-12 -->
+<!-- Schema: default -->
+<!-- Audit: B.7.2 (docs/new-archetypes-plan.md §6.2 — ai-native-rag scaffolder; first slice: dispatch registration) -->
+
+## Problem
+
+B.7.1 shipped `.forge/schemas/ai-native-rag/1.0.0.yaml` (candidate,
+scaffoldable:false) but **did not register the archetype in the CLI dispatch
+table**. The independent review of `b7-1-schema` (Q-005) found that
+`forge init --archetype ai-native-rag` therefore refuses with **exit 2**
+("unknown archetype") at the dispatch-table gate (`init.ts:210`), never reaching
+the intended schema-version refusal (exit 3). Both are clean refusals, but exit 3
+is the canonical "registered archetype with no scaffoldable schema version"
+state (the deferred B.8.3.b guard). This change is the first additive slice of
+B.7.2: register the archetype so the refusal becomes exit 3, resolving Q-005. It
+ships **no templates, no scaffold-plan, no standards, no pins** — the archetype
+stays non-scaffoldable.
+
+**Ground truth (re-read 2026-06-12, Article III.4):**
+
+- **dispatch-table entry schema** (`.forge/scaffolding/dispatch-table.yml`,
+  FR-IW-002): `name` (== map key), `scaffolder` (`<built-in>` | repo-relative
+  shell path), `description`, `signals` (list), `since` (SemVer). The parser
+  (`cli/src/domain/dispatch-table.ts`) also tolerates `status`. `ai-native-rag`
+  is absent; `default` / `full-stack-monorepo` / `mobile-only` / `flutter-firebase`
+  are present.
+- **The unknown-archetype gate** `init.ts:210-216` returns **exit 2** for any
+  archetype not in `dispatchTable.archetypes`. Registering ai-native-rag removes
+  this gate for it, so control reaches the versioned-schema layer.
+- **The refusal path** `init.ts:225-238` → `resolveScaffolder`
+  (`init-archetype.ts:128-154`): with `metas.length > 0` and
+  `selectScaffoldableVersion(metas) === null` it returns `{kind:"refuse"}` →
+  **exit 3**, *without touching the scaffolder path*. `readArchetypeSchemas`
+  (`cli.ts:135-156`) is **generic** — it reads `<assets>/.forge/schemas/
+  <archetype>/*.yaml` for any archetype via `parseSchemaMeta`. So for
+  ai-native-rag it returns `[{1.0.0, candidate, scaffoldable:false}]` (non-empty)
+  → `selectScaffoldableVersion` null → exit 3. **Verified by reading the code.**
+  (If `metas` were empty — e.g. schema not bundled — line 137 falls back to legacy
+  `kind:"ok"` and would try to run the wrapper; hence the schema MUST be bundled
+  into `cli/assets` alongside the dispatch entry, which `npm run bundle` does.)
+- **The scaffolder-exists gate** `b5.test.sh::test_dispatch_scaffolders_exist`
+  (FR-IW-002, lines 142-165) statically requires every entry's `scaffolder` to be
+  a real file, OR the sentinel `<built-in>`/`<removed>`, OR `status:
+  removed_from_roadmap`. So a registered ai-native-rag entry pointing at a
+  non-existent script would FAIL this gate.
+- **The documented ABI** (dispatch-table.yml header): "Adding a new archetype =
+  (1) appending one entry here + (2) writing the corresponding
+  `bin/forge-init-<archetype>.sh` wrapper following the stable ABI declared in
+  `global/scaffolding.md`."
+- **Framework version** is `0.4.0` (`cli/package.json`, `cli/VERSION`); the
+  `[Unreleased]` CHANGELOG section is the next cut (→ ADR-B7-2A / Q-001 for the
+  `since:` value).
+
+## Solution
+
+Register `ai-native-rag` and ship a **refusing wrapper** so the refusal flips to
+exit 3 cleanly, with no scaffold capability added.
+
+1. **Dispatch entry** in `.forge/scaffolding/dispatch-table.yml`:
+   `name: ai-native-rag`, `scaffolder: bin/forge-init-ai-native-rag.sh`,
+   `description` (one-line), `signals: []` (no `--auto` detection yet),
+   `since:` (the next framework version). Optional `status:` marker documenting
+   not-yet-scaffoldable.
+2. **`bin/forge-init-ai-native-rag.sh`** — a thin wrapper that **refuses**
+   (exit 3) with a clear "ai-native-rag is not yet scaffoldable (candidate
+   schema; the B.7.2 scaffolder + templates are not shipped yet)". This satisfies
+   `test_dispatch_scaffolders_exist` (real file), follows the documented
+   entry+wrapper ABI, and is the wrapper-side defense-in-depth layer (mirroring
+   `_refuse_if_forbidden`, J.8) for the case where the CLI guard is bypassed. The
+   CLI's own `resolveScaffolder` refusal (exit 3) fires *first*, so the wrapper
+   is belt-and-suspenders today; B.7.2-full replaces its body with the real
+   scaffold logic.
+3. **Flip `b7-1.test.sh` L2** (`_test_b71_l2_001_init_refuses`): the verified
+   live exit is now **3** (registered + non-scaffoldable), not 2. Update the
+   assertion + docstring (the prior code already flagged this flip "once B.7.2
+   registers it").
+4. **Harness `b7-2a.test.sh`**: dispatch entry present & well-formed; wrapper
+   exists/executable/refuses exit 3 when invoked directly; (opt-in live) the CLI
+   refuses ai-native-rag with exit 3.
+
+Decisions reserved for `/forge:design` (ADRs), leanings stated:
+
+- **ADR-B7-2A-001 — refusing wrapper vs sentinel scaffolder.** Lean: **refusing
+  wrapper** (option above). Alternative — `scaffolder: "<pending>"` sentinel +
+  teaching `b5.test.sh` to skip it — is rejected: it edits an existing test and
+  diverges from the documented entry+wrapper ABI.
+- **ADR-B7-2A-002 — refusal exit code = 3.** Lean: exit 3 (the B.8.3.b
+  not-scaffoldable refusal + the J.8 policy-refusal convention), consistent
+  between the CLI guard and the wrapper.
+- **ADR-B7-2A-003 — wrapper message + non-destructiveness.** Lean: structured
+  stderr (`[REFUSAL: ai-native-rag: not-yet-scaffoldable ...]`), exit 3, zero
+  filesystem writes.
+
+## Scope In
+
+- `.forge/scaffolding/dispatch-table.yml` — one `ai-native-rag` entry.
+- `bin/forge-init-ai-native-rag.sh` — refusing wrapper (exit 3, no writes).
+- `.forge/scripts/tests/b7-1.test.sh` — L2 assertion flip (exit 2 → exit 3).
+- `.forge/scripts/tests/b7-2a.test.sh` — new harness; registered in `forge-ci.yml`.
+- Change artifacts (`proposal/specs/design/tasks/open-questions`).
+
+## Scope Out (Explicit Exclusions)
+
+- **Templates / scaffold-plan** `templates/archetypes/ai-native-rag/**` — B.7.2-full.
+- **Standards** llm-gateway/mcp-servers/rag-patterns — B.7.3.
+- **Version pins** (`rmcp`, pgvector crate) — verify-then-pin in B.7.2-full/B.7.3.
+- **Promotion to stable/scaffoldable** — the schema stays candidate; promotion is
+  the B.7 scaffolder-completion brick (gated on a green b7-6 harness, ADR-B7-1-002).
+- **The real scaffold body** of the wrapper — B.7.2-full.
+- **`--auto` signals** — left empty (no detection heuristics for ai-native-rag yet).
+
+## Impact
+
+- **Users**: `forge init --archetype ai-native-rag` now refuses with exit 3 (was
+  exit 2). Still no scaffold produced — the archetype is announced as "known but
+  not yet available". No other archetype's behaviour changes.
+- **Technical**: one dispatch entry + one refusing wrapper + test updates. The
+  runtime flip relies on the schema being bundled into `cli/assets` (done by
+  `npm run bundle` at build, as for every archetype).
+- **Dependencies**: B.7.1 (the schema) + B.8.14 (the CLI refusal path). Unblocks
+  the full B.7.2 scaffolder + B.7.3 standards (which flesh out the wrapper).
+
+## Constitution Compliance
+
+- **III.1/III.2 (Specs before code)**: propose+specify first; TDD at impl
+  (b7-2a harness RED before the entry/wrapper).
+- **III.4 (Anti-Hallucination)**: every claim (refusal precedence, generic
+  readArchetypeSchemas, the b5 scaffolder-exists gate, the ABI) re-read from live
+  code; the `since:` value is flagged as an open question, not guessed.
+- **IV (Delta-based)**: additive — the dispatch entry + wrapper are new; the only
+  existing-file edits are the dispatch table (append), the b7-1 L2 assertion
+  (reflecting verified new behaviour), and the CI matrix (harness registration).
+- **V (Compliance gate)**: ADRs map to design resolutions; independent review +
+  maintainer ratification before archive.
+- **XII (Governance)**: no Constitution amendment.
+
+## Open Questions (seed)
+
+- **Q-001** — `since:` value for the dispatch entry (0.5.0 next-minor vs 0.4.1
+  patch) — verify against `docs/VERSIONING.md` at design.
+- **Q-002** — does the entry carry a `status:` marker (e.g. `candidate` /
+  `not_scaffoldable`) for human clarity, and if so should `b5.test.sh` treat it
+  specially? (Leaning: a documentary `status:` is harmless; no b5 change needed
+  because the wrapper file exists.)

--- a/.forge/changes/b7-2a-dispatch-register/specs.md
+++ b/.forge/changes/b7-2a-dispatch-register/specs.md
@@ -1,0 +1,102 @@
+# Specifications: b7-2a-dispatch-register
+
+<!-- Status: specified -->
+<!-- Schema: default -->
+<!-- Audit: B.7.2 (docs/new-archetypes-plan.md §6.2 — ai-native-rag dispatch registration slice) -->
+
+**Namespace** : `FR-B7-2A-*` / `NFR-B7-2A-*` / `ADR-B7-2A-*`.
+**Constitution** : v2.0.0, unchanged. Additive. Resolves `b7-1-schema` Q-005.
+**Governing articles** : III.1/III.2 (specs before code), III.4 (anti-hallucination),
+IV (delta/additive), I (TDD — harness RED before the entry/wrapper).
+
+## Source Documents
+
+| Field | Value |
+|-------|-------|
+| **Plan ref** | `docs/new-archetypes-plan.md` §6.2 B.7.2 (scaffolder); this is its first additive slice (dispatch registration only) |
+| **Q-005 (origin)** | `.forge/changes/b7-1-schema/open-questions.md` + `.forge/specs/ai-native-rag.md` — `forge init` refuses exit 2 (unknown), flip to exit 3 deferred here |
+| **Dispatch schema (observed)** | `.forge/scaffolding/dispatch-table.yml` FR-IW-002: name/scaffolder/description/signals/since (+ tolerated `status`); parser `cli/src/domain/dispatch-table.ts` |
+| **Unknown-archetype gate (observed)** | `init.ts:210-216` → exit 2 when archetype ∉ dispatchTable.archetypes |
+| **Refusal path (observed)** | `init.ts:225-238` → `resolveScaffolder` (`init-archetype.ts:128-154`): metas non-empty + `selectScaffoldableVersion` null ⇒ `{kind:"refuse"}` ⇒ exit 3, scaffolder untouched. `readArchetypeSchemas` (`cli.ts:135-156`) generic over `<assets>/.forge/schemas/<archetype>/*.yaml`. Caveat: empty metas (line 137) ⇒ legacy `kind:"ok"` ⇒ would run the wrapper — so the schema must be bundled. |
+| **Scaffolder-exists gate (observed)** | `b5.test.sh::test_dispatch_scaffolders_exist` (142-165): scaffolder must be a real file OR `<built-in>`/`<removed>` OR `status: removed_from_roadmap` |
+| **ABI (observed)** | dispatch-table.yml header + `global/scaffolding.md`: entry + `bin/forge-init-<archetype>.sh` wrapper |
+| **Framework version (observed)** | 0.4.0 (`cli/package.json`, `cli/VERSION`); `[Unreleased]` is next |
+| **Downstream** | B.7.2-full (templates + scaffold-plan + real wrapper body + promotion), B.7.3 (standards) |
+| **Release target** | maintainer-set ([Unreleased]) |
+
+---
+
+## ADDED Requirements
+
+### Functional
+
+##### FR-B7-2A-001 — dispatch entry present & well-formed
+`.forge/scaffolding/dispatch-table.yml` MUST gain an `ai-native-rag` entry with
+`name: ai-native-rag` (== key), `scaffolder: bin/forge-init-ai-native-rag.sh`,
+a one-line `description`, `signals: []`, and a `since:` SemVer (Q-001).
+
+##### FR-B7-2A-002 — refusing wrapper exists, executable, ABI-shaped
+`bin/forge-init-ai-native-rag.sh` MUST exist, be executable, be `bash`, and
+follow the `global/scaffolding.md` wrapper ABI shape. Its body MUST refuse:
+print a structured `[REFUSAL: ai-native-rag: not-yet-scaffoldable ...]` to stderr
+and exit 3, performing **zero** filesystem writes (ADR-B7-2A-003).
+
+##### FR-B7-2A-003 — CLI refusal flips exit 2 → exit 3
+After registration, `forge init <name> --archetype ai-native-rag --org <rd>` MUST
+exit **3** (the `resolveScaffolder` no-scaffoldable-version refusal), no longer
+exit 2. No scaffold is produced. (Relies on the candidate schema being bundled
+into `cli/assets` — NFR-B7-2A-002.)
+
+##### FR-B7-2A-004 — scaffolder-exists gate stays GREEN
+`b5.test.sh::test_dispatch_scaffolders_exist` MUST stay GREEN: the new entry's
+scaffolder path resolves to the real `bin/forge-init-ai-native-rag.sh` (no
+`b5.test.sh` edit required — FR-B7-2A-002 provides the file).
+
+##### FR-B7-2A-005 — b7-1 L2 assertion flipped to exit 3
+`.forge/scripts/tests/b7-1.test.sh` `_test_b71_l2_001_init_refuses` MUST assert
+exit **3** (updated docstring), reflecting the now-registered, non-scaffoldable
+state. The CI-mode skip-pass gating (`FORGE_B7_1_LIVE`) is unchanged.
+
+##### FR-B7-2A-006 — dedicated harness
+`.forge/scripts/tests/b7-2a.test.sh` MUST assert: (L1) the dispatch entry is
+present & well-formed; the wrapper exists/executable/bash and refuses exit 3 when
+invoked directly with zero writes; (L2, opt-in `FORGE_B7_2A_LIVE` + built CLI,
+skip-pass otherwise) the CLI refuses ai-native-rag with exit 3. Registered in
+`.github/workflows/forge-ci.yml`.
+
+### Non-Functional
+
+##### NFR-B7-2A-001 — additive / minimal blast radius
+No templates/standards/pins/scaffold-plan. Existing-file edits limited to: the
+dispatch table (append), the b7-1 L2 assertion (verified new behaviour), the CI
+matrix (harness registration). No schema/constitution/standard touched. The
+schema stays `candidate` / `scaffoldable: false` (no promotion).
+
+##### NFR-B7-2A-002 — runtime flip requires the schema bundled
+The exit-3 flip depends on `<assets>/.forge/schemas/ai-native-rag/1.0.0.yaml`
+being present so `readArchetypeSchemas` returns a non-empty metas list (else the
+legacy `metas.length===0` fallback would try to run the wrapper). `npm run
+bundle` copies it (as for every archetype); the L2 fixture documents the
+build prerequisite.
+
+##### NFR-B7-2A-003 — no regression
+`verify.sh`, `constitution-linter.sh`, `b5.test.sh`, and the full harness suite
+stay GREEN after the change.
+
+## ADRs (seeded — resolved at /forge:design)
+
+- **ADR-B7-2A-001** — refusing wrapper (not a `<pending>` sentinel + b5 edit).
+- **ADR-B7-2A-002** — refusal exit code 3 (CLI guard + wrapper, consistent).
+- **ADR-B7-2A-003** — wrapper: structured stderr refusal, exit 3, zero writes.
+
+## Acceptance Criteria (impl)
+
+1. `ai-native-rag` entry in dispatch-table.yml (name/scaffolder/description/
+   signals/since).
+2. `bin/forge-init-ai-native-rag.sh` exists, executable; direct invocation → exit 3,
+   no writes.
+3. `forge init <name> --archetype ai-native-rag --org <rd>` → exit 3 (live).
+4. `b5.test.sh` GREEN (scaffolder-exists); `b7-1.test.sh` L2 asserts exit 3.
+5. `b7-2a.test.sh` GREEN; registered in forge-ci.yml.
+6. `verify.sh` + `constitution-linter.sh` no regression; schema unchanged
+   (still candidate/scaffoldable:false).

--- a/.forge/changes/b7-2a-dispatch-register/specs.md
+++ b/.forge/changes/b7-2a-dispatch-register/specs.md
@@ -64,13 +64,35 @@ invoked directly with zero writes; (L2, opt-in `FORGE_B7_2A_LIVE` + built CLI,
 skip-pass otherwise) the CLI refuses ai-native-rag with exit 3. Registered in
 `.github/workflows/forge-ci.yml`.
 
+##### FR-B7-2A-007 — CLI e2e couplings kept green (Q-003)
+Registering an active archetype couples to the T5.1 CLI e2e suite. This change
+MUST keep `cd cli && npm test` green:
+- `cli/src/cli.ts` `--archetype` help text MUST name `ai-native-rag`, and the
+  `init.snap.txt` help snapshot MUST be regenerated (`help-snapshots.test.ts`
+  enumerates active archetypes).
+- `cli/test/e2e/archetypes-smoke.test.ts` MUST partition `status === "candidate"`
+  out of the fixture/scaffold matrix and assert candidates refuse with **exit 3 +
+  no scaffold** (no fixture required). Scaffoldable archetypes keep the exit-0 +
+  file-matrix contract.
+
 ### Non-Functional
 
 ##### NFR-B7-2A-001 — additive / minimal blast radius
-No templates/standards/pins/scaffold-plan. Existing-file edits limited to: the
-dispatch table (append), the b7-1 L2 assertion (verified new behaviour), the CI
-matrix (harness registration). No schema/constitution/standard touched. The
-schema stays `candidate` / `scaffoldable: false` (no promotion).
+No templates/standards/pins/scaffold-plan. No schema/constitution/standard
+touched; the schema stays `candidate` / `scaffoldable: false` (no promotion).
+Existing-file edits are confined to the dispatch registration and its **tested
+couplings** (corrected post-review — the first author pass under-scoped this):
+- `.forge/scaffolding/dispatch-table.yml` (append the entry),
+- the b7-1 L2 assertion (verified exit-2→3 flip) + the CI matrix (harness reg),
+- **`cli/src/cli.ts`** `--archetype` help text + the `init.snap.txt` help snapshot
+  — `help-snapshots.test.ts` asserts every non-`removed_from_roadmap` archetype is
+  named in `forge init --help`,
+- **`cli/test/e2e/archetypes-smoke.test.ts`** — partitions `candidate` (refusing,
+  exit 3, no fixture) from scaffoldable archetypes (fixture + scaffold matrix), so
+  registering a non-scaffoldable archetype does not break the smoke contract.
+Registering an **active** archetype has a hard coupling to these CLI e2e tests
+(they enumerate active dispatch-table archetypes); the ground-truth pass must
+include them (Article III.4 lesson, Q-003).
 
 ##### NFR-B7-2A-002 — runtime flip requires the schema bundled
 The exit-3 flip depends on `<assets>/.forge/schemas/ai-native-rag/1.0.0.yaml`

--- a/.forge/changes/b7-2a-dispatch-register/specs.md
+++ b/.forge/changes/b7-2a-dispatch-register/specs.md
@@ -74,6 +74,10 @@ MUST keep `cd cli && npm test` green:
   out of the fixture/scaffold matrix and assert candidates refuse with **exit 3 +
   no scaffold** (no fixture required). Scaffoldable archetypes keep the exit-0 +
   file-matrix contract.
+- `.forge/scripts/tests/t5-1.test.sh::_test_t51_l1_016_dispatch_xref` (the SHELL
+  mirror of the smoke fixture cross-reference, FR-T51-055) MUST exclude
+  `status: candidate` from the fixture requirement — found in CI after the first
+  two fixes (it is a third test enumerating active archetypes).
 
 ### Non-Functional
 

--- a/.forge/changes/b7-2a-dispatch-register/tasks.md
+++ b/.forge/changes/b7-2a-dispatch-register/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: b7-2a-dispatch-register
 
-<!-- Status: implemented -->
+<!-- Status: archived -->
 <!-- Schema: default -->
 <!-- Audit: B.7.2 (docs/new-archetypes-plan.md §6.2 — ai-native-rag dispatch registration slice) -->
 
@@ -59,8 +59,10 @@ test updates. Harness authored FIRST and must fail before the entry/wrapper exis
   artifacts; edits limited to dispatch-table (append), b7-1 L2, CI matrix. Schema
   unchanged (still candidate/scaffoldable:false). [NFR-B7-2A-001]
 - [x] **T4.3** REFACTOR; re-run full b7-2a + b7-1 harness → GREEN.
-- [ ] **T4.4** `/forge:review b7-2a-dispatch-register` — independent reviewer
-  APPROVE + maintainer ratification (Article V).
+- [x] **T4.4** `/forge:review b7-2a-dispatch-register` — independent reviewer
+  **APPROVE** (2026-06-12, after one fix iteration on the CRITICAL/HIGH CLI-e2e
+  regression) + **maintainer ratification** of ADR-B7-2A-001..005 + Q-003
+  (2026-06-12). Article V satisfied (reviewer was a separate context). Archived.
 
 ## Constitution Gate (per task)
 - TDD: harness RED (T1.2) before entry/wrapper GREEN (T2.3). ✓

--- a/.forge/changes/b7-2a-dispatch-register/tasks.md
+++ b/.forge/changes/b7-2a-dispatch-register/tasks.md
@@ -44,6 +44,13 @@ test updates. Harness authored FIRST and must fail before the entry/wrapper exis
   exit 3 live. If no build: rely on L2 skip-pass + document. [Story: FR-B7-2A-003]
 - [x] **T3.4** Register `b7-2a.test.sh` in `.github/workflows/forge-ci.yml`
   (after `b7-1.test.sh`). [Story: FR-B7-2A-006]
+- [x] **T3.5** (post-review Q-003) `cli/src/cli.ts` `--archetype` help text +=
+  `ai-native-rag`; regen `cli/test/e2e/__snapshots__/help/init.snap.txt` via
+  `npx vitest run -u`. [Story: FR-B7-2A-007]
+- [x] **T3.6** (post-review Q-003) `cli/test/e2e/archetypes-smoke.test.ts`:
+  partition `status === "candidate"` out of the fixture/scaffold matrix; add a
+  refusal test asserting candidates exit 3 + no scaffold. `cd cli && npm test` →
+  87 passed / 1 skipped. [Story: FR-B7-2A-007]
 
 ## Phase 4: Quality
 

--- a/.forge/changes/b7-2a-dispatch-register/tasks.md
+++ b/.forge/changes/b7-2a-dispatch-register/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: b7-2a-dispatch-register
+
+<!-- Status: implemented -->
+<!-- Schema: default -->
+<!-- Audit: B.7.2 (docs/new-archetypes-plan.md §6.2 — ai-native-rag dispatch registration slice) -->
+
+TDD-ordered (Article I). Deliverable: one dispatch entry + one refusing wrapper +
+test updates. Harness authored FIRST and must fail before the entry/wrapper exist.
+
+## Phase 1: RED — failing harness
+
+- [x] **T1.1** Author `.forge/scripts/tests/b7-2a.test.sh` (sources `_helpers.sh`).
+  L1: dispatch entry `ai-native-rag` present & well-formed (name/scaffolder/
+  description/signals/since/status via the python dispatch parse); wrapper
+  `bin/forge-init-ai-native-rag.sh` exists + executable + `#!/usr/bin/env bash`;
+  direct invocation (in a tmpdir) → exit 3 + structured `[REFUSAL: ...]` stderr +
+  **zero files written**. L2 (opt-in `FORGE_B7_2A_LIVE` + `cli/dist/index.js`,
+  skip-pass otherwise): `forge init testproj --archetype ai-native-rag --org
+  com.example.test` → exit 3. [Story: FR-B7-2A-001/002/003/006]
+- [x] **T1.2** Run `bash .forge/scripts/tests/b7-2a.test.sh --level 1` → **verify
+  RED** (no entry, no wrapper). [Gate: Article I]
+
+## Phase 2: GREEN
+
+- [x] **T2.1** Append the `ai-native-rag` entry to
+  `.forge/scaffolding/dispatch-table.yml`: `name`, `scaffolder:
+  bin/forge-init-ai-native-rag.sh`, `description`, `signals: []`, `since: "0.5.0"`
+  (ADR-B7-2A-004), `status: candidate` (ADR-B7-2A-005). [Story: FR-B7-2A-001]
+- [x] **T2.2** Write `bin/forge-init-ai-native-rag.sh` — executable bash refusing
+  wrapper: structured `[REFUSAL: ai-native-rag: not-yet-scaffoldable ...]` to
+  stderr, `exit 3`, zero filesystem writes; ABI-shaped arg tolerance
+  (ADR-B7-2A-003). `chmod +x`. [Story: FR-B7-2A-002]
+- [x] **T2.3** Run `b7-2a.test.sh --level 1` → **verify GREEN**. [Gate: Article I]
+
+## Phase 3: Integration
+
+- [x] **T3.1** Flip `.forge/scripts/tests/b7-1.test.sh`
+  `_test_b71_l2_001_init_refuses` to assert **exit 3** (+ docstring: now
+  registered, refusal is the schema-version layer). [Story: FR-B7-2A-005]
+- [x] **T3.2** Run `b5.test.sh` → `test_dispatch_scaffolders_exist` GREEN (the
+  wrapper path resolves). [Story: FR-B7-2A-004]
+- [x] **T3.3** (build available) `npm run bundle` then `FORGE_B7_2A_LIVE=1
+  b7-2a.test.sh --level 2` + `FORGE_B7_1_LIVE=1 b7-1.test.sh --level 1,2` → CLI
+  exit 3 live. If no build: rely on L2 skip-pass + document. [Story: FR-B7-2A-003]
+- [x] **T3.4** Register `b7-2a.test.sh` in `.github/workflows/forge-ci.yml`
+  (after `b7-1.test.sh`). [Story: FR-B7-2A-006]
+
+## Phase 4: Quality
+
+- [x] **T4.1** `verify.sh` + `constitution-linter.sh` → no regression. [NFR-B7-2A-003]
+- [x] **T4.2** `git diff --name-only` → additive: new wrapper + harness + change
+  artifacts; edits limited to dispatch-table (append), b7-1 L2, CI matrix. Schema
+  unchanged (still candidate/scaffoldable:false). [NFR-B7-2A-001]
+- [x] **T4.3** REFACTOR; re-run full b7-2a + b7-1 harness → GREEN.
+- [ ] **T4.4** `/forge:review b7-2a-dispatch-register` — independent reviewer
+  APPROVE + maintainer ratification (Article V).
+
+## Constitution Gate (per task)
+- TDD: harness RED (T1.2) before entry/wrapper GREEN (T2.3). ✓
+- Additive; every task cites its FR/NFR/ADR. ✓ No [TASK VIOLATION].

--- a/.forge/scaffolding/dispatch-table.yml
+++ b/.forge/scaffolding/dispatch-table.yml
@@ -63,6 +63,22 @@ archetypes:
     target: mobile-pwa-first
     migration: "B.9 (T8) — bin/forge-migrate-mobile-pwa.sh"
 
+  ai-native-rag:
+    name: ai-native-rag
+    scaffolder: "bin/forge-init-ai-native-rag.sh"
+    description: "AI-first RAG archetype — pgvector + LLM gateway (Mistral-EU / vLLM) + MCP servers + Qwik streaming UI. Registered candidate; not yet scaffoldable (templates ship in B.7.2)."
+    signals: []
+    since: "0.5.0"
+    # B.7.2a (b7-2a-dispatch-register) — REGISTERED, NOT YET SCAFFOLDABLE.
+    # The 1.0.0 schema is `stage: candidate` / `scaffoldable: false`
+    # (.forge/schemas/ai-native-rag/1.0.0.yaml, B.7.1), so the CLI versioned-schema
+    # layer refuses `forge init --archetype ai-native-rag` with exit 3
+    # (resolveScaffolder → no scaffoldable version, init-archetype.ts:128). The
+    # scaffolder wrapper below is a refusing stub (defense in depth) until B.7.2
+    # ships templates + the real body and promotes the schema to stable/scaffoldable.
+    # Resolves b7-1-schema Q-005. `since: 0.5.0` per VERSIONING.md (new archetype ⇒ MINOR).
+    status: candidate
+
   # ─── Removed from taxonomy (t4-adr-ratification, 2026-05-04) ────
   # `flutter-firebase` was a placeholder slot for archetype B.2 in the
   # original audit roadmap (`il-s-agit-l-d-un-noble-gem.md`). Per ADR-007

--- a/.forge/scripts/tests/b7-1.test.sh
+++ b/.forge/scripts/tests/b7-1.test.sh
@@ -23,7 +23,7 @@
 #   T-017  ai_fallback_required True + cross_layer.agent Janus + fr_id_prefix_cross_layer FR-GL- (FR-B7-1-013/024)
 #
 #   T-018  header block documents candidate semantics (candidate/scaffoldable/additive) (FR-B7-1-005)
-#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 2 unknown-archetype refusal (dispatch-table gate; FORGE_B7_1_LIVE=1 + built CLI; skip-pass otherwise)
+#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 3 (registered by B.7.2a, no scaffoldable schema version; FORGE_B7_1_LIVE=1 + built CLI; skip-pass otherwise)
 #
 # 18 L1 + 1 L2 tests. Performance budget: L1 ≤ 5 s, zero net/Docker. Structural
 # invariants (name==dir, version==file, layer triple, candidate=>scaffoldable:false,
@@ -328,29 +328,27 @@ _test_b71_l1_018_header_block() {
 # ─── L2 tests (opt-in live) ───────────────────────────────────────────────────
 
 _test_b71_l2_001_init_refuses() {
-  # The refusal contract (verified live against the built CLI, 2026-06-11):
-  # `forge init <name> --archetype ai-native-rag --org <rd>` exits **2**
-  # ("unknown archetype"). init.ts:210-216 checks the dispatch-table FIRST, and
-  # ai-native-rag is not registered in .forge/scaffolding/dispatch-table.yml, so
-  # the dispatch gate fires before the schema-version layer. The exit-3
-  # selectScaffoldableVersion-null guard (init.ts:232-238) is DOWNSTREAM and not
-  # reachable for this archetype yet; it becomes the active gate only once B.7.2
-  # registers ai-native-rag in the dispatch-table while the schema stays
-  # candidate/scaffoldable:false (update this assertion to exit 3 then — see
-  # open-questions.md Q-005). Either way init refuses cleanly with NO scaffold
-  # (NFR-B7-1-002). Opt-in (FORGE_B7_1_LIVE=1) + requires cli/dist/index.js;
-  # skip-pass otherwise (mirrors b8-15 FORGE_B8_15_LIVE).
+  # The refusal contract (Q-005 flip — B.7.2a registered ai-native-rag in the
+  # dispatch-table 2026-06-12): `forge init <name> --archetype ai-native-rag
+  # --org <rd>` now exits **3**. The archetype passes the init.ts:210
+  # dispatch-table gate (registered) and reaches the versioned-schema layer;
+  # selectScaffoldableVersion returns null for the candidate/scaffoldable:false
+  # 1.0.0 schema (init-archetype.ts:128) ⇒ resolveScaffolder refuse ⇒ exit 3
+  # (init.ts:232-238). Clean refusal, NO scaffold (NFR-B7-1-002). Requires the
+  # built CLI to have the B.7.2a dispatch entry + schema bundled into cli/assets
+  # (npm run bundle). Opt-in (FORGE_B7_1_LIVE=1) + cli/dist/index.js; skip-pass
+  # otherwise (mirrors b8-15 FORGE_B8_15_LIVE).
   local cli="$FORGE_ROOT/cli/dist/index.js"
   if [ "${FORGE_B7_1_LIVE:-0}" != "1" ] || [ ! -f "$cli" ]; then
-    echo "    SKIP T-L2-001: set FORGE_B7_1_LIVE=1 with a built CLI (cli/dist/index.js) to run the live init-refusal check" >&2
+    echo "    SKIP T-L2-001: set FORGE_B7_1_LIVE=1 with a built+bundled CLI (cli/dist/index.js) to run the live init-refusal check" >&2
     return 0
   fi
   local tmp; tmp=$(mk_tmpdir_with_trap b7-1-init)
   trap "rm -rf '$tmp'" RETURN
   ( cd "$tmp" && node "$cli" init testproj --archetype ai-native-rag --org com.example.test >/dev/null 2>&1 )
   local rc=$?
-  if [ "$rc" != "2" ]; then
-    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 2 (expected clean refusal — unknown archetype; dispatch-table gate, init.ts:210)" >&2
+  if [ "$rc" != "3" ]; then
+    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 3 (expected clean refusal — registered but no scaffoldable schema version; B.7.2a/Q-005)" >&2
     return 1
   fi
 }

--- a/.forge/scripts/tests/b7-2a.test.sh
+++ b/.forge/scripts/tests/b7-2a.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Forge — B.7.2a ai-native-rag dispatch registration harness
+# <!-- Audit: B.7.2 (b7-2a-dispatch-register) — dispatch entry + refusing wrapper gate -->
+#
+# Validates the b7-2a-dispatch-register deliverables (resolves b7-1-schema Q-005):
+#
+#   T-001  dispatch-table.yml has a well-formed ai-native-rag entry (FR-B7-2A-001)
+#   T-002  bin/forge-init-ai-native-rag.sh exists, executable, bash shebang (FR-B7-2A-002)
+#   T-003  direct wrapper invocation ⇒ exit 3 + [REFUSAL ...] stderr + zero writes (FR-B7-2A-002/003)
+#   T-L2-001 (opt-in) forge init --archetype ai-native-rag ⇒ exit 3 (FR-B7-2A-003 ;
+#            FORGE_B7_2A_LIVE=1 + built CLI; skip-pass otherwise)
+#
+# 3 L1 + 1 L2. Performance budget: L1 ≤ 3 s, zero net/Docker.
+
+set -uo pipefail
+
+LEVEL="1"
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--level" ]; then LEVEL="$arg"; fi
+  case "$arg" in --level=*) LEVEL="${arg#*=}" ;; esac
+  prev="$arg"
+done
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$HARNESS_DIR/.." && pwd)"
+FORGE_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+DISPATCH="$FORGE_ROOT/.forge/scaffolding/dispatch-table.yml"
+WRAPPER="$FORGE_ROOT/bin/forge-init-ai-native-rag.sh"
+
+# shellcheck source=./_helpers.sh
+source "$HARNESS_DIR/_helpers.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+# ─── L1 ───────────────────────────────────────────────────────────────────────
+
+_test_b72a_l1_001_dispatch_entry() {
+  python3 - "$DISPATCH" <<'PY' || return 1
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1])) or {}
+e = (d.get("archetypes") or {}).get("ai-native-rag")
+errs = []
+if e is None:
+    print("    FAIL T-001: no 'ai-native-rag' entry in dispatch-table.yml (FR-B7-2A-001)", file=sys.stderr)
+    sys.exit(1)
+if e.get("name") != "ai-native-rag":
+    errs.append(f"name={e.get('name')!r} != 'ai-native-rag'")
+if e.get("scaffolder") != "bin/forge-init-ai-native-rag.sh":
+    errs.append(f"scaffolder={e.get('scaffolder')!r} != 'bin/forge-init-ai-native-rag.sh'")
+if not (isinstance(e.get("description"), str) and e.get("description").strip()):
+    errs.append("description missing/empty")
+if not isinstance(e.get("signals"), list):
+    errs.append(f"signals not a list (got {type(e.get('signals')).__name__})")
+if e.get("since") != "0.5.0":
+    errs.append(f"since={e.get('since')!r} != '0.5.0' (ADR-B7-2A-004)")
+if e.get("status") != "candidate":
+    errs.append(f"status={e.get('status')!r} != 'candidate' (ADR-B7-2A-005)")
+if errs:
+    for x in errs: print(f"    FAIL T-001: {x}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+_test_b72a_l1_002_wrapper_exists_executable() {
+  if [ ! -f "$WRAPPER" ]; then echo "    FAIL T-002: wrapper missing: $WRAPPER (FR-B7-2A-002)" >&2; return 1; fi
+  if [ ! -x "$WRAPPER" ]; then echo "    FAIL T-002: wrapper not executable: $WRAPPER" >&2; return 1; fi
+  head -1 "$WRAPPER" | grep -qE '^#!.*\bbash\b' || { echo "    FAIL T-002: wrapper missing bash shebang" >&2; return 1; }
+}
+
+_test_b72a_l1_003_wrapper_refuses_no_writes() {
+  [ -x "$WRAPPER" ] || { echo "    FAIL T-003: wrapper not runnable (covered by T-002)" >&2; return 1; }
+  local tmp; tmp=$(mk_tmpdir_with_trap b7-2a-wrap)
+  trap "rm -rf '$tmp'" RETURN
+  local err rc
+  err=$( cd "$tmp" && "$WRAPPER" testproj --org com.example.test 2>&1 1>/dev/null ); rc=$?
+  if [ "$rc" != "3" ]; then
+    echo "    FAIL T-003: wrapper exit=$rc != 3 (ADR-B7-2A-002)" >&2; return 1
+  fi
+  printf '%s' "$err" | grep -qiE '\[REFUSAL' || { echo "    FAIL T-003: wrapper stderr lacks [REFUSAL ...] (ADR-B7-2A-003); got: $err" >&2; return 1; }
+  # zero writes: tmpdir must still be empty
+  if [ -n "$(ls -A "$tmp" 2>/dev/null)" ]; then
+    echo "    FAIL T-003: wrapper wrote files into the target dir (must be a no-op refusal): $(ls -A "$tmp")" >&2; return 1
+  fi
+}
+
+# ─── L2 (opt-in live) ─────────────────────────────────────────────────────────
+
+_test_b72a_l2_001_cli_refuses_exit3() {
+  # Registered + candidate/scaffoldable:false ⇒ resolveScaffolder refuse ⇒ exit 3.
+  # Requires the dispatch entry + schema bundled into cli/assets (npm run bundle).
+  local cli="$FORGE_ROOT/cli/dist/index.js"
+  if [ "${FORGE_B7_2A_LIVE:-0}" != "1" ] || [ ! -f "$cli" ]; then
+    echo "    SKIP T-L2-001: set FORGE_B7_2A_LIVE=1 with a built+bundled CLI (cli/dist/index.js) to run the live exit-3 check" >&2
+    return 0
+  fi
+  local tmp; tmp=$(mk_tmpdir_with_trap b7-2a-init)
+  trap "rm -rf '$tmp'" RETURN
+  ( cd "$tmp" && node "$cli" init testproj --archetype ai-native-rag --org com.example.test >/dev/null 2>&1 )
+  local rc=$?
+  if [ "$rc" != "3" ]; then
+    echo "    FAIL T-L2-001: forge init --archetype ai-native-rag exit=$rc != 3 (registered, not scaffoldable)" >&2; return 1
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo "── B.7.2a — b7-2a-dispatch-register — level $LEVEL ──"
+  run_test _test_b72a_l1_001_dispatch_entry
+  run_test _test_b72a_l1_002_wrapper_exists_executable
+  run_test _test_b72a_l1_003_wrapper_refuses_no_writes
+  case "$LEVEL" in
+    *2*) run_test _test_b72a_l2_001_cli_refuses_exit3 ;;
+  esac
+  print_summary
+}
+
+main

--- a/.forge/scripts/tests/t5-1.test.sh
+++ b/.forge/scripts/tests/t5-1.test.sh
@@ -331,8 +331,12 @@ _test_t51_l1_016_dispatch_xref() {
   fi
   # Parse archetype names from dispatch-table top-level entries (2-space
   # indent under `archetypes:`). Filter out `default` (covered by
-  # cli.test.ts) and entries flagged removed_from_roadmap (detected via
-  # the `<removed>` scaffolder sentinel or an explicit `status:` field).
+  # cli.test.ts), entries flagged removed_from_roadmap (detected via the
+  # `<removed>` scaffolder sentinel or an explicit `status:` field), and
+  # `status: candidate` entries — B.7.2a registered-but-not-yet-scaffoldable
+  # archetypes (e.g. ai-native-rag) have no scaffold fixture; their refusal
+  # is covered by b7-2a.test.sh + archetypes-smoke.test.ts. They rejoin this
+  # fixture cross-reference when promoted to stable/scaffoldable (B.7.2-full).
   local in_archetypes=0
   local current=""
   local current_status=""
@@ -351,6 +355,7 @@ _test_t51_l1_016_dispatch_xref() {
         # Flush the previous archetype if any.
         if [ -n "$current" ] && [ "$current" != "default" ] \
            && [ "$current_status" != "removed_from_roadmap" ] \
+           && [ "$current_status" != "candidate" ] \
            && [ "$current_scaffolder" != "<removed>" ]; then
           if [ ! -f "$FIXTURES_DIR/$current.yml" ]; then
             missing+="$current "
@@ -373,6 +378,7 @@ _test_t51_l1_016_dispatch_xref() {
   # Flush the last entry.
   if [ -n "$current" ] && [ "$current" != "default" ] \
      && [ "$current_status" != "removed_from_roadmap" ] \
+     && [ "$current_status" != "candidate" ] \
      && [ "$current_scaffolder" != "<removed>" ]; then
     if [ ! -f "$FIXTURES_DIR/$current.yml" ]; then
       missing+="$current "

--- a/.forge/specs/ai-native-rag.md
+++ b/.forge/specs/ai-native-rag.md
@@ -113,3 +113,63 @@ B.7.2 (`b7-2-scaffolder` — registers ai-native-rag in dispatch-table.yml, ship
 templates + scaffold-plan, flips exit-2→exit-3 then stable+scaffoldable), B.7.3
 (`b7-standards` — llm-gateway/mcp-servers/rag-patterns), `b7-pythia` (K.2),
 `b7-9-janus-ai` (J.8.c), `b7-5-ai-act`, `b7-7-example`, `b7-6-harness`.
+
+---
+
+## ADDED Requirements (b7-2a-dispatch-register, archived 2026-06-12)
+
+**Namespace** : `FR-B7-2A-*` / `NFR-B7-2A-*` / `ADR-B7-2A-*`. First additive slice
+of B.7.2 — registers the archetype in the CLI dispatch table so `forge init
+--archetype ai-native-rag` refuses with **exit 3** (registered, no scaffoldable
+schema version) instead of exit 2 (unknown archetype). Resolves Q-005. Ships no
+templates/scaffold-plan/standards/pins; the schema stays candidate/scaffoldable:false.
+
+Deliverables: `.forge/scaffolding/dispatch-table.yml` (ai-native-rag entry),
+`bin/forge-init-ai-native-rag.sh` (refusing wrapper, exit 3, zero writes),
+`.forge/scripts/tests/b7-2a.test.sh` (3 L1 + 1 L2, in forge-ci.yml).
+
+### Functional
+
+- **FR-B7-2A-001** — dispatch entry present & well-formed (name/scaffolder/
+  description/signals/since/status).
+- **FR-B7-2A-002** — refusing wrapper exists, executable, bash, ABI-shaped; refuses
+  exit 3 with `[REFUSAL ...]` stderr and zero filesystem writes.
+- **FR-B7-2A-003** — CLI refusal flips exit 2 → exit 3 (verified live).
+- **FR-B7-2A-004** — `b5.test.sh::test_dispatch_scaffolders_exist` stays GREEN (the
+  wrapper is a real file; no b5 edit).
+- **FR-B7-2A-005** — `b7-1.test.sh` L2 assertion flipped to exit 3.
+- **FR-B7-2A-006** — dedicated harness `b7-2a.test.sh`, registered in forge-ci.yml.
+- **FR-B7-2A-007** — CLI e2e couplings kept green (Q-003): `cli/src/cli.ts`
+  `--archetype` help text names ai-native-rag + regen `init.snap.txt`;
+  `archetypes-smoke.test.ts` partitions `candidate` out of the scaffold matrix and
+  asserts exit-3 refusal + no scaffold. `cd cli && npm test` 87 passed / 1 skipped.
+
+### Non-Functional
+
+- **NFR-B7-2A-001** — additive: no templates/standards/pins; schema untouched.
+  Existing-file edits confined to dispatch-table (append), b7-1 L2 flip, CI matrix,
+  and the tested CLI couplings (cli.ts help + snapshot, archetypes-smoke partition).
+- **NFR-B7-2A-002** — runtime flip requires the schema + entry bundled into
+  `cli/assets` (`npm run bundle`).
+- **NFR-B7-2A-003** — verify.sh / constitution-linter.sh / b5 / full harness suite
+  no regression.
+
+### ADRs (ratified — maintainer 2026-06-12; independent reviewer APPROVE)
+
+- **ADR-B7-2A-001** — refusing wrapper, not a `<pending>` sentinel + b5 edit.
+- **ADR-B7-2A-002** — refusal exit code 3 (CLI guard + wrapper, consistent).
+- **ADR-B7-2A-003** — wrapper: structured `[REFUSAL ...]` stderr, exit 3, zero writes.
+- **ADR-B7-2A-004** — `since: "0.5.0"` (VERSIONING.md — new archetype ⇒ MINOR).
+- **ADR-B7-2A-005** — documentary `status: candidate`; no b5.test.sh change.
+
+### Open questions (resolved)
+
+- **Q-001** (`since:` value) → 0.5.0 (ADR-B7-2A-004). **Q-002** (`status:` marker)
+  → `candidate` (ADR-B7-2A-005). Both at design.
+- **Q-003** (independent review, CRITICAL/HIGH): registering an active archetype
+  couples to the T5.1 CLI e2e tests (`help-snapshots`, `archetypes-smoke`) that
+  enumerate active dispatch-table archetypes — `cd cli && npm test` would fail in
+  CI. Resolved: candidate stays discoverable in `--help` + refusal-asserted in
+  smoke (partitioned out of the scaffold matrix). Lesson (Article III.4): the
+  ground-truth pass must include e2e dispatch-table cross-reference tests, and the
+  gate run must include `npm test`. B.7.2-full re-checks these couplings at promotion.

--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -121,6 +121,7 @@ jobs:
             "b8-14-flip.test.sh --level 1"
             "b8o.test.sh --level 1"
             "b7-1.test.sh --level 1,2"
+            "b7-2a.test.sh --level 1,2"
           )
           fail=0
           for entry in "${harnesses[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ minor bump and will be called out under a `### BREAKING` subsection.
 
 ### Added
 
+- **`ai-native-rag` dispatch registration (B.7.2a, `b7-2a-dispatch-register`)** —
+  registers the archetype in `.forge/scaffolding/dispatch-table.yml` (since 0.5.0,
+  `status: candidate`) + a refusing wrapper `bin/forge-init-ai-native-rag.sh`. This
+  flips `forge init --archetype ai-native-rag` from the exit-2 "unknown archetype"
+  refusal to the canonical **exit-3** "no scaffoldable schema version" refusal
+  (the B.8.3.b guard) — the archetype is now *known but not yet scaffoldable*,
+  with **zero** scaffold produced. Resolves the b7-1-schema Q-005 follow-up.
+  `--help` lists the archetype; the e2e smoke suite asserts its refusal.
+  Harness `b7-2a.test.sh` (3 L1 + 1 L2) in `forge-ci.yml`. Additive — the schema
+  stays candidate/scaffoldable:false. Independent reviewer APPROVE; ADRs ratified.
+
 - **`ai-native-rag` archetype scaffold schema (B.7.1, `b7-1-schema`)** — first
   brick of the T7 AI-native RAG archetype chain (plan §6.2). Ships
   `.forge/schemas/ai-native-rag/1.0.0.yaml` as `stage: candidate` /

--- a/bin/forge-init-ai-native-rag.sh
+++ b/bin/forge-init-ai-native-rag.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Forge — `forge init --archetype ai-native-rag` wrapper
+# <!-- Audit: B.7.2 (b7-2a-dispatch-register) — refusing stub -->
+#
+# REGISTERED, NOT YET SCAFFOLDABLE. The ai-native-rag archetype is declared
+# (`.forge/scaffolding/dispatch-table.yml`) and its 1.0.0 schema is
+# `stage: candidate` / `scaffoldable: false` (.forge/schemas/ai-native-rag/
+# 1.0.0.yaml, B.7.1). The CLI versioned-schema layer (cli/src/commands/init.ts →
+# resolveScaffolder) refuses `forge init --archetype ai-native-rag` with exit 3
+# BEFORE this wrapper is ever invoked.
+#
+# This file is the wrapper-side defense-in-depth layer (mirrors
+# bin/_forge-init-helpers.sh::_refuse_if_forbidden, J.8): if the CLI guard is
+# bypassed and the wrapper is called directly, it refuses identically — exit 3,
+# structured stderr, and ZERO filesystem writes (never a partial scaffold).
+#
+# B.7.2 (full scaffolder) replaces this body with the real scaffold logic
+# (templates + scaffold-plan + pins from B.7.3) and promotes the schema to
+# stable/scaffoldable. Until then: refuse.
+#
+# Stable ABI shape (B.5.1) — flags are accepted for ABI compatibility and ignored;
+# no action is taken on any of them:
+#   forge-init-ai-native-rag.sh --target <dir> --project-name <slug> \
+#       --reverse-domain <fqdn> [--force]
+#
+# Refusal exit code: 3 (no scaffoldable schema version ; mirrors the B.8.3.b /
+# ADR-J8-003 policy-refusal convention).
+
+set -euo pipefail
+
+# All ABI flags (--target / --project-name / --reverse-domain / --force) and any
+# positional args are accepted-and-ignored: this wrapper reads none of them and
+# performs NO work — it refuses unconditionally before touching the filesystem.
+# (Deliberately no arg-parsing loop, so a value-less flag can't trip `set -e`.)
+
+echo "[REFUSAL: ai-native-rag: not-yet-scaffoldable: the ai-native-rag schema is a candidate (scaffoldable:false) — templates ship in B.7.2 ; alternative: use --archetype full-stack-monorepo, or 'default' then add RAG components manually]" >&2
+exit 3

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -74,7 +74,7 @@ export async function runCli(io: CliIo): Promise<number> {
       "--source <dir>",
       "local Forge source checkout (default: the files bundled with this CLI)",
     )
-    .option("--archetype <name>", "explicit archetype (e.g. default | full-stack-monorepo | mobile-only)")
+    .option("--archetype <name>", "explicit archetype (e.g. default | full-stack-monorepo | mobile-only | ai-native-rag)")
     .option("--auto", "auto-detect archetype from target dir signals", false)
     .option("--wizard", "force interactive wizard mode", false)
     .option("--org <reverse-domain>", "reverse domain (required for non-default archetypes)")

--- a/cli/test/e2e/__snapshots__/help/init.snap.txt
+++ b/cli/test/e2e/__snapshots__/help/init.snap.txt
@@ -11,7 +11,7 @@ Options:
   --source <dir>          local Forge source checkout (default: the files
                           bundled with this CLI)
   --archetype <name>      explicit archetype (e.g. default |
-                          full-stack-monorepo | mobile-only)
+                          full-stack-monorepo | mobile-only | ai-native-rag)
   --auto                  auto-detect archetype from target dir signals
                           (default: false)
   --wizard                force interactive wizard mode (default: false)

--- a/cli/test/e2e/archetypes-smoke.test.ts
+++ b/cli/test/e2e/archetypes-smoke.test.ts
@@ -2,9 +2,9 @@
 //
 // Layer T5.1.B — smoke test per archetype (FR-T51-040..055).
 //
-// For each active archetype in dispatch-table.yml (skipping `default`,
-// `removed_from_roadmap`, and `legacy_alias` entries whose target is
-// also present), this suite :
+// For each active SCAFFOLDABLE archetype in dispatch-table.yml (skipping
+// `default`, `removed_from_roadmap`, and — B.7.2a — `candidate` entries that are
+// registered but not yet scaffoldable), this suite :
 //
 //   1. Creates a tmpdir path that does NOT yet exist on disk (exercises
 //      the v0.3.2 `mkdir -p` fix in init-archetype.ts:148).
@@ -95,6 +95,14 @@ function missingToolsFor(archetypeName: string): string[] {
 
 describe("T5.1.B — smoke per archetype", () => {
   const archetypes = activeArchetypes();
+  // B.7.2a — a `candidate` archetype is registered in the dispatch table +
+  // discoverable in `--help`, but is NOT yet scaffoldable (its schema is
+  // stage:candidate / scaffoldable:false), so `forge init` refuses it with exit 3
+  // (resolves b7-1-schema Q-005). Candidates are excluded from the scaffold/
+  // fixture matrix and exercised instead by the dedicated refusal test below;
+  // they rejoin the scaffold matrix when promoted to stable/scaffoldable (B.7.2).
+  const scaffoldable = archetypes.filter((a) => a.status !== "candidate");
+  const candidates = archetypes.filter((a) => a.status === "candidate");
   // Partition at module-load so vitest can render the skipped archetypes
   // as `↓ skipped` instead of relying on a runtime `ctx.skip()` call —
   // `it.each` in vitest 2.1.x does NOT pass a TestContext to the
@@ -102,11 +110,11 @@ describe("T5.1.B — smoke per archetype", () => {
   // (verified 2026-05-18 on PR #21 CI : `Cannot read properties of
   // undefined (reading 'skip')`). Static partitioning is the canonical
   // skip pattern that keeps the CI output audit-friendly.
-  const runnable = archetypes.filter((a) => missingToolsFor(a.name).length === 0);
-  const skippedDueToToolchain = archetypes.filter((a) => missingToolsFor(a.name).length > 0);
+  const runnable = scaffoldable.filter((a) => missingToolsFor(a.name).length === 0);
+  const skippedDueToToolchain = scaffoldable.filter((a) => missingToolsFor(a.name).length > 0);
 
-  it("dispatch-table cross-reference: every active archetype has a fixture (FR-T51-055)", () => {
-    for (const a of archetypes) {
+  it("dispatch-table cross-reference: every scaffoldable archetype has a fixture (FR-T51-055)", () => {
+    for (const a of scaffoldable) {
       const path = join(FIXTURES_DIR, `${a.name}.yml`);
       expect(
         existsSync(path),
@@ -114,6 +122,44 @@ describe("T5.1.B — smoke per archetype", () => {
       ).toBe(true);
     }
   });
+
+  // B.7.2a (FR-B7-2A-003) — registered-but-non-scaffoldable (candidate)
+  // archetypes MUST refuse cleanly with exit 3 and produce NO scaffold (the
+  // target dir is never created — the resolveScaffolder refusal fires before
+  // runArchetypeInit's mkdir). No fixture is required for these.
+  if (candidates.length > 0) {
+    it.each(candidates.map((a) => [a.name]))(
+      "refuses %s (candidate / not-yet-scaffoldable) with exit 3 + no scaffold",
+      async (archetypeName) => {
+        const tmp = await mkdtemp(join(tmpdir(), `forge-refuse-${archetypeName}-`));
+        await rm(tmp, { recursive: true, force: true });
+        createdTmpdirs.push(tmp);
+        const r = spawnSync(
+          process.execPath,
+          [
+            CLI_ENTRY,
+            "init",
+            slugFor(archetypeName),
+            "--archetype",
+            archetypeName,
+            "--org",
+            "dev.forge.test",
+            "--target",
+            tmp,
+          ],
+          { encoding: "utf8", env: { ...process.env, NO_COLOR: "1" } },
+        );
+        expect(
+          r.status,
+          `forge init must refuse candidate archetype '${archetypeName}' with exit 3:\n${r.stderr}`,
+        ).toBe(3);
+        expect(
+          existsSync(tmp),
+          `candidate archetype '${archetypeName}' must not scaffold (target dir must not be created)`,
+        ).toBe(false);
+      },
+    );
+  }
 
   // Statically-skipped declarations — visible in the test report as
   // intentionally skipped (not silent pass), so reviewers can see at a


### PR DESCRIPTION
## What

First additive slice of **B.7.2** (T7 ai-native-rag chain). Registers the `ai-native-rag` archetype in the CLI dispatch table so `forge init --archetype ai-native-rag` stops refusing with exit 2 ("unknown archetype") and instead refuses with the canonical **exit 3** ("no scaffoldable schema version" — the B.8.3.b guard). The archetype is now *known but not yet scaffoldable*; **zero** scaffold is produced. **Resolves Q-005** from b7-1-schema (PR #22).

Full Forge pipeline: propose → specify → design → plan → implement → review → archive.

## Deliverables (additive)

- `.forge/scaffolding/dispatch-table.yml` — `ai-native-rag` entry (`since: 0.5.0` per VERSIONING new-archetype⇒MINOR; `status: candidate`).
- `bin/forge-init-ai-native-rag.sh` — refusing wrapper (exit 3, structured `[REFUSAL ...]`, **zero filesystem writes**); satisfies the b5 scaffolder-exists gate + the entry+wrapper ABI; wrapper-side defense-in-depth. B.7.2-full replaces the body.
- `.forge/scripts/tests/b7-2a.test.sh` — 3 L1 + 1 L2 (opt-in `FORGE_B7_2A_LIVE`), in `forge-ci.yml`.
- `b7-1.test.sh` L2 flipped exit 2 → 3.
- CLI e2e kept green: `cli/src/cli.ts` `--archetype` help text + `init.snap.txt`; `archetypes-smoke.test.ts` partitions `candidate` (asserts refusal, not scaffold).

## Decisions (ADR-B7-2A-001..005, ratified)

Refusing wrapper (not a sentinel); exit 3 (CLI guard + wrapper); structured stderr + zero writes; `since: 0.5.0`; documentary `status: candidate`.

## Review trail (Article V)

Independent reviewer caught a **CI-breaking regression** (registering an *active* archetype couples to two T5.1 e2e tests that enumerate dispatch-table archetypes — `cd cli && npm test` would fail without updating the help text/snapshot + the smoke partition). Fixed in `5bc340b`, re-verified, then **APPROVE**. ADRs ratified. Lesson recorded in Q-003.

## Verification

- **Live**: `forge init --archetype ai-native-rag` → exit 3, `[B.8.3.b scaffoldable guard]`, zero files written (built+bundled CLI).
- `cd cli && npm test` → **87 passed / 1 skipped** (16 files)
- `b7-2a.test.sh` 4/4 + `b7-1.test.sh` 19/19 (CI + live)
- `verify.sh` PASS · `constitution-linter.sh` OVERALL PASS · `b5` scaffolder-exists PASS

## Scope

Schema untouched (still candidate/scaffoldable:false — promotion is B.7.2-full). Spec merged to `.forge/specs/ai-native-rag.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)