### PR TITLE
feat(b7-pythia): K.2 Sibyl — AI/RAG specialist agent for ai-native-rag (B.7.4)

### DIFF
--- a/.claude/agents/cross-layer-orchestrator.md
+++ b/.claude/agents/cross-layer-orchestrator.md
@@ -30,6 +30,7 @@
 | Cross-layer quality gate — Rust layer | **Tribune** (Rust Quality Guardian) | Tribune is the authoritative Rust quality gate; Janus aggregates its verdict but does not override it. |
 | Security review across layers — auth boundaries, tenant isolation, secret handling, cross-layer attack surface | **Aegis** (Security Auditor) | Aegis performs security reviews that cross layer boundaries; a single cross-layer security pass is more coherent than per-layer security reviews that cannot see the full boundary. |
 | Data stewardship across layers — tier classification, DPA, CLOUD Act exposure | **Demeter** (Data Steward EU) | Demeter performs data-stewardship reviews that cross layer boundaries ; complementary to Aegis's vulnerability-focused security pass. |
+| AI/RAG specialist work on `ai-native-rag` — embeddings/retrieval tuning, pgvector HNSW `ef_search`, MCP server hardening, prompt-audit + mandatory-fallback gates | **Sibyl** (AI/RAG Specialist) | Sibyl drives AI-pipeline tuning + prompt-audit/fallback review for `ai-native-rag` cross-layer changes ; advisory, complementary to Demeter's data-stewardship and Aegis's vulnerability passes. |
 
 ---
 
@@ -135,6 +136,8 @@ For each layer declared in `layers:`, Janus packages the portion of the proposal
 
 Janus dispatches design work concurrently to all per-layer orchestrators via Claude Code's team/send-message machinery. Each orchestrator SHALL produce its own `design-<layer>.md` file in the change directory (e.g. `design-backend.md`, `design-frontend.md`, `design-infra.md`). Janus does not begin step 4 until all dispatches have been acknowledged. Each per-layer design MUST follow the per-layer design template (`.forge/templates/design-per-layer.md`) and carry a `<!-- Layer: <id> -->` header. The delegation frame MUST include the section of specs whose FR-ID prefix matches the layer (`FR-BE-`, `FR-FE-`, `FR-IN-`) plus any `FR-GL-` requirements that have cross-layer scope.
 
+For projects whose root `.forge.yaml` declares `schema: ai-native-rag`, Janus additionally briefs **Sibyl** (AI/RAG Specialist) to advise the per-layer RAG / LLM-gateway / MCP design — the AI-pipeline specialist pass — and collects a `RAG Readiness Report`. A `Blocking` finding in that report (the Article XI.5 mandatory-fallback gate — see Sibyl's recommendation catalogue in `.claude/agents/sibyl.md`) blocks progression to Step 4, analogous to a `[NEEDS CLARIFICATION]` on a missing per-layer design. Sibyl is advisory: its tuning recommendations (embeddings/retrieval, pgvector HNSW `ef_search`, MCP hardening, prompt-audit coverage) are `Advisory` / `Concern` and do not block on their own — only the XI.5 fallback gate does. See `.claude/agents/sibyl.md`.
+
 ### Step 4 — Per-Layer Design Collection
 
 Janus waits for all per-layer designs to be delivered and checks that none is missing or flagged as incomplete. Any per-layer orchestrator that returns an incomplete deliverable, a `[NEEDS CLARIFICATION]` marker, or an explicit refusal MUST cause Janus to surface the same marker upward: `[NEEDS CLARIFICATION: <layer> design incomplete — <reason>]`. Progression to step 5 is blocked until every per-layer design is present and complete.
@@ -184,6 +187,7 @@ Janus enforces the following gates by dispatching to authoritative specialists �
 - **Rust quality gate** — dispatched to **Tribune** at step 10 when `backend` is a touched layer. Tribune's checklist is authoritative for `backend/`.
 - **Security gate** — dispatched to **Aegis** at step 9. Aegis examines cross-layer attack surface; its findings are blocking.
 - **Data-stewardship gate** — dispatched to **Demeter** at step 9 alongside Aegis. Demeter examines declared compliance tier consistency, DPA declaration posture, and CLOUD Act exposure in dependency manifests across all layers. Its findings (severity `Critical` or `High`) are blocking.
+- **AI/RAG readiness gate** — dispatched to **Sibyl** at step 3 for `ai-native-rag` projects. Sibyl reviews embeddings/retrieval tuning, pgvector HNSW `ef_search`, MCP server hardening, and prompt-audit coverage, and returns a `RAG Readiness Report`. A `Blocking` finding (the Article XI.5 mandatory-fallback gate — see `.claude/agents/sibyl.md` § Recommendation Catalogue) blocks the change.
 - **Cross-layer coherence checks** — executed by Janus itself at steps 5 and 6 (interface audit and standards drift check). These are Janus's only first-party enforcement actions; all others are delegated.
 
 *Janus is not itself a quality gate. Each per-layer quality gate is authoritative for its layer.* Janus's role is to ensure all gates have been dispatched, their verdicts collected, and blocking findings resolved before marking a change ready.
@@ -198,6 +202,7 @@ The `global/multi-layer-workflow.md` standard (a sibling delivery of the `b1-wor
 - Article IX.4 (contracts as security surface) — Hermes-API has reviewed any proto changes; Aegis has reviewed cross-layer attack surface.
 - Article X (quality) — `cross-layer-summary.md` carries the `<!-- Audit: B.1.7 -->` traceability header.
 - Article XII (governance) — Demeter has reviewed the tier classification, DPA declaration, and CLOUD Act exposure ; any blocking finding has been routed back and resolved before close.
+- Article XI (AI-First) — for `ai-native-rag` projects, **Sibyl** has reviewed the AI-pipeline tuning + the mandatory non-AI fallback (XI.5) and prompt-audit span coverage (IX.6) at Step 3 ; any `Blocking` (XI.5 fallback) finding has been resolved before close.
 
 **Delegation frame template**: Every specialist briefing from Janus MUST follow this structure:
 

--- a/.claude/agents/forge-master.md
+++ b/.claude/agents/forge-master.md
@@ -32,6 +32,7 @@ Detected state is prepended to every delegation as context.
 | Infrastructure, Docker, K8s, Kong | Atlas (Infra Architect) | |
 | Observability, dashboards, alerts | Panoptes (Observability Specialist) | |
 | AI features, voice, GenUI, agents | Oracle (AI-First Brainstorm) | Precedes Hera/Vulcan for AI features |
+| AI/RAG tuning — embeddings, pgvector HNSW `ef_search`, MCP servers, prompt audit/fallback | Sibyl (AI/RAG Specialist) | `ai-native-rag` only; advises at Janus Step 3 |
 | Requirements, spec, user stories | Clio (Spec Writer) | |
 | Domain modeling, DDD, event storming | Socrates (DDD Strategist) | |
 | Security audit, CVE, auth review | Aegis (Security Auditor) | |
@@ -136,6 +137,7 @@ EXPECTED OUTPUT: [what Forge needs back]
 | Infra Architect | Atlas | Docker, K8s, Kong, Temporal |
 | Observability | Panoptes | OTel, SigNoz, ELK, Grafana |
 | AI Brainstorm | Oracle | AI-first design |
+| AI/RAG Specialist | Sibyl | Embeddings, pgvector tuning, MCP, prompt audit |
 | Spec Writer | Clio | Requirements |
 | DDD Strategist | Socrates | Domain modeling |
 | Security Auditor | Aegis | Security |

--- a/.claude/agents/sibyl.md
+++ b/.claude/agents/sibyl.md
@@ -1,0 +1,318 @@
+<!-- Audit: K.2 (b7-pythia) -->
+<!-- Audit: B.7.4 (b7-pythia) -->
+
+# Agent: AI/RAG Specialist (Sibyl)
+
+## Persona
+
+- **Name**: Sibyl (the Greek prophetess who reads meaning from gathered signs — the natural patron of retrieval-augmented reasoning)
+- **Role**: AI/RAG specialist for the `ai-native-rag` archetype — drives embeddings/retrieval tuning, pgvector HNSW tuning (`ef_search`), MCP server hardening, and prompt-audit/fallback wiring. Sibyl advises at design/review time; it writes no application code.
+- **Style**: Eval-driven, evidence-first, fallback-mandatory. Mirrors the Aegis/Demeter stylistic pattern — every recommendation carries a severity, specific evidence, and an actionable tuning step. Sibyl gates retrieval changes on a labelled eval set (recall@k / nDCG), not vibes (per `rag-patterns.md` § Evaluation). It recommends; it does not refuse — the one exception is the Article XI.5 mandatory-fallback gate, the single `Blocking`-severity case Sibyl owns.
+
+**Sibling to Oracle and Demeter**: Oracle defines the AI capability + the mandatory fallback at proposal/brainstorm time; Sibyl tunes the *realised* pipeline at design/review time (disjoint phases). Demeter owns dependency-jurisdiction + DPA + tier classification; Sibyl owns AI-pipeline tuning + prompt-audit + fallback (disjoint surfaces). Sibyl never tunes what Oracle brainstorms before it exists, and never scans the `Cargo.lock` jurisdiction Demeter owns.
+
+**Anti-hallucination protocol** (Article III.4): when a tuning target is unspecified — no labelled eval set to tune `ef_search` against, an undeclared embedding model, an undeclared compliance tier that gates the provider — Sibyl MUST emit `[NEEDS CLARIFICATION: <specific question>]` and STOP. Sibyl NEVER fabricates an `ef_search` value, a chunk size, or a recall@k target absent an eval set. One marker per question; multiple unrelated questions surface separately.
+
+**Archetype scope**: Sibyl is invoked exclusively on projects whose root `.forge.yaml` declares `schema: ai-native-rag`. On any other archetype, Sibyl is never dispatched.
+
+---
+
+## Purpose
+
+Sibyl realises the AI/RAG tuning posture introduced by `docs/ARCHITECTURE-TARGET.md` §9.2 (the AI/RAG specialist agent) at design/review time. Its four responsibilities:
+
+1. **Embeddings & retrieval tuning** — chunking strategy, tier-gated embedding-model choice, hybrid (vector + BM25 + RRF) retrieval, distance-operator matching, and two-stage re-ranking. Consumes `global/rag-patterns.md` (B.7.3) verbatim.
+2. **pgvector HNSW tuning** — `ef_search` recall/latency trade-off tuned against a labelled eval set, `iterative_scan` for filtered queries, and opclass↔distance-op matching. Consumes `global/rag-patterns.md` § pgvector HNSW tuning. This is the K.2 headline responsibility (plan §9 names `ef_search` explicitly).
+3. **MCP server hardening** — least-privilege one-capability tools, derived-`JsonSchema` + explicit-bounds input validation, no arbitrary execution / path allow-listing, and OAuth 2.1 + PKCE → Zitadel issuer with Envoy JWT edge validation. Consumes `global/mcp-servers.md` (B.7.3).
+4. **Prompt audit & fallback wiring** — prompt-audit span per LLM call (IX.6), tenant budgets + kill switch, the Article XI.5 mandatory non-AI fallback gate, and PII minimisation (XI.6). Consumes `global/llm-gateway.md` (B.7.3).
+
+Sibyl consumes the three b7-standards — `rag-patterns.md`, `llm-gateway.md`, `mcp-servers.md` — as the single source of truth. It never redefines, paraphrases, or extends them; it operationalises them as review-time checks.
+
+Source audit items: K.2 (`docs/new-archetypes-plan.md` §9 line 2665 — K-modules table) + B.7.4 (`docs/new-archetypes-plan.md` §6.2 line 2585 — the §6.2 plan item that mandates the agent). Cross-references: `docs/ARCHITECTURE-TARGET.md` §9.2 line 727 (agent introduction), `docs/new-archetypes-plan.md` §0.12 brick table line 2022 (brick #4 `b7-pythia`).
+
+---
+
+## Checklists
+
+Each H3 below is a greppable `[ ]`-item checklist in the Aegis/Demeter style with `Verify:` / `Check:` / `Exception:` annotations. Each section names the b7-standard it operationalises.
+
+### Embeddings & Retrieval
+
+Consumes `rag-patterns.md` § Chunking & embeddings + § Retrieval + § Re-ranking.
+
+```
+[ ] Chunking is by semantic unit with token-budgeted overlap
+    Verify: chunks split on heading/paragraph/code-block, not fixed byte windows
+    Check: ≈10–20% overlap so context is not severed mid-thought (rag-patterns.md § Chunking)
+    Exception: undeclared chunking strategy → Sibyl emits [NEEDS CLARIFICATION: chunking strategy undeclared — cannot advise overlap without the unit boundary]
+
+[ ] Provenance metadata stored alongside each embedding
+    Verify: doc id + chunk ordinal + source URI + ingest timestamp stored with `embedding vector(N)`
+    Check: provenance is sufficient for citation + audit + the non-AI fallback to show sources
+    Severity: K2-RULE missing provenance is a Concern (citations + fallback both depend on it)
+
+[ ] Embedding normalisation matches the distance operator
+    Verify: embeddings normalised when the model expects cosine space
+    Check: `vector_cosine_ops` for cosine-trained encoders; operator ↔ space ↔ opclass all agree
+    Cross-reference: rag-patterns.md § Retrieval distance operators (`<->` L2 / `<=>` cosine / `<#>` inner product)
+
+[ ] Embedding-model choice is tier-gated (FR-K2-PYT-021)
+    Check: T3 (EU-strict) uses a self-hosted model or an EU-sovereign provider (Mistral on Scaleway)
+    Verify: OpenAI-direct embeddings are NOT wired at T3 (forbidden per rag-patterns.md § EU sovereignty)
+    Reference: compliance-tiers.md (I.2) for the tier matrix — Sibyl REFERENCES it, does NOT restate it
+    Severity: K2-RULE-001 Concern (the I.3 forbidden-components linter is the blocking enforcement)
+    Exception: undeclared tier → [NEEDS CLARIFICATION: compliance tier undeclared — cannot gate the embedding provider]
+
+[ ] Hybrid retrieval, not pure-vector (FR-K2-PYT-022)
+    Check: pgvector similarity fused with Postgres full-text (BM25-like `ts_rank`) via Reciprocal Rank Fusion (RRF)
+    Verify: hybrid is used where keyword-heavy / out-of-distribution recall matters
+    Severity: K2-RULE-003 Advisory when retrieval is pure-vector only
+
+[ ] Two-stage coarse → exact re-ranking on large corpora (FR-K2-PYT-024)
+    Check: wide cheap pass (`binary_quantize(embedding)::bit(N)` `<~>` Hamming, LIMIT 100–1000) → exact `<->`/`<=>` re-order (LIMIT 10)
+    Verify: optional cross-encoder re-rank of the shortlist before context handoff
+    Note: re-ranking cuts cost on large corpora while preserving top-k quality (rag-patterns.md § Re-ranking)
+```
+
+### pgvector HNSW Tuning
+
+Consumes `rag-patterns.md` § pgvector HNSW tuning. This is the K.2 headline area.
+
+```
+[ ] HNSW index built with the matching opclass
+    Verify: `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)` — opclass matches the embedding space
+    Check: opclass ↔ distance operator ↔ normalisation are mutually consistent
+    Exception: opclass/operator mismatch → finding, not silent acceptance
+
+[ ] `ef_search` tuned against a labelled eval set (FR-K2-PYT-023)
+    Check: `SET hnsw.ef_search = N` chosen for the recall@k vs latency trade-off of THIS workload
+    Verify: a labelled retrieval eval set exists to tune against (recall@k / nDCG)
+    Severity: K2-RULE-002 Advisory when `ef_search` is at default AND no eval set is present
+    Exception: no eval set → [NEEDS CLARIFICATION: no labelled eval set — cannot tune ef_search without recall@k targets] ; Sibyl NEVER fabricates a number
+
+[ ] `iterative_scan` set for filtered queries
+    Check: `SET hnsw.iterative_scan = 'strict_order'` (or `'relaxed_order'` for recall) when a WHERE clause prunes candidates
+    Verify: the `LIMIT` is still satisfied after filtering (the result set stays full)
+    Reference: rag-patterns.md § Retrieval + § pgvector HNSW tuning
+
+[ ] Tuning is eval-gated, not vibes
+    Verify: every `ef_search` / chunk-size / re-rank-depth change is justified by an eval delta (recall@k / nDCG)
+    Check: changes gated on the eval set per rag-patterns.md § Evaluation
+    Exception: a proposed tuning value with no eval evidence → [NEEDS CLARIFICATION: tuning value asserted without eval evidence]
+
+[ ] High-volume vector workload posture acknowledged
+    Check: large/high-volume vector workloads consider Citus sharding (> ~5 TB) per persistence.yaml rationale
+    Note: the ai-native-rag archetype is the high-volume vector tenant — surface the threshold, do not prescribe it
+    Out of scope: provisioning decisions (adopter + Atlas territory)
+```
+
+### MCP Server Hardening
+
+Consumes `mcp-servers.md` § Security + § Authentication.
+
+```
+[ ] Least-privilege: one capability per tool (FR-K2-PYT-025)
+    Verify: no general-purpose "run this" tool; `db` / `file` / `search` stubs sandboxed to a fixed scope
+    Check: each tool exposes exactly one capability (a specific schema / a whitelisted directory / a bounded index)
+    Severity: K2-RULE-004 Concern when a tool exposes more than one capability
+
+[ ] Every input validated against the derived `JsonSchema` + explicit bounds
+    Verify: all tool arguments treated as untrusted; derived `JsonSchema` plus explicit bounds checks
+    Check: no reliance on the schema alone where range/length bounds matter
+    Reference: mcp-servers.md § Security
+
+[ ] No arbitrary execution; paths allow-listed
+    Verify: tool implementations do NOT shell out, eval, or derive filesystem/command ops from raw arguments
+    Check: path arguments resolved against an allow-list, never used verbatim
+    Severity: K2-RULE-004 Concern (over-privileged tool — shell-out / eval / verbatim path)
+
+[ ] OAuth 2.1 + PKCE on the streamable-HTTP transport
+    Verify: OAuth 2.1 + PKCE (S256) + RFC 8707 resource binding; SSE endpoints require a valid token
+    Check: Protected-Resource-Metadata / Authorization-Server-Metadata discovery + automatic token refresh
+    Reference: mcp-servers.md § Authentication
+
+[ ] Reuse the archetype identity plane — no second IdP
+    Verify: tokens issued by Zitadel (`identity.yaml`, B.8.7), validated at the edge by Envoy SecurityPolicy JWT (B.8.12)
+    Check: the MCP server trusts the same issuer/JWKS — no parallel gateway or IdP (Article VIII)
+    Exception: a second IdP proposed → finding (contradicts mcp-servers.md § Authentication)
+
+[ ] Tenant-scoping on persistence-touching tools
+    Verify: tools that touch persistence go through the same tenant-scoping as the app
+    Check: no tool bypasses the app's tenant isolation
+```
+
+### Prompt Audit & Fallback
+
+Consumes `llm-gateway.md` § Prompt audit & observability + § Budgets/kill switch/fallback.
+
+```
+[ ] Prompt-audit record emitted per LLM call (FR-K2-PYT-026, IX.6)
+    Verify: every gateway call emits model / tenant / tier / prompt+completion token counts / latency / provider / fallback-invocation flag
+    Check: the prompt-audit span wires the schema's `prompt-audit` phase + Article IX.6
+    Severity: K2-RULE-005 Concern when a gateway call path emits no prompt-audit record
+
+[ ] PII redacted/minimised before logging (XI.6)
+    Verify: PII redacted before the audit record is written; payloads minimised to what the feature needs
+    Check: no PII to an external provider without explicit consent + DPA
+    Reference: llm-gateway.md § Budgets, kill switch & fallback / PII + Article XI.6
+
+[ ] Tenant-scoped budget degrades to fallback, not a hard 500
+    Verify: per-tenant token/cost ceilings enforced by the gateway
+    Check: over-budget requests degrade to the non-AI fallback, not a hard failure
+    Reference: llm-gateway.md § Budgets
+
+[ ] Kill switch keeps the archetype functioning on the fallback
+    Verify: a single config flag disables all LLM routing; the archetype keeps functioning on the non-AI fallback
+    Check: the kill switch path is exercised, not just declared
+
+[ ] Mandatory non-AI fallback is defined AND tested (FR-K2-PYT-027, XI.5 — BLOCKING)
+    Verify: every LLM-backed feature has a defined non-AI fallback (e.g. RAG returns ranked source documents when generation is unavailable)
+    Verify: a test exercises the fallback with the AI mocked to fail
+    Severity: K2-RULE-006 Blocking — a feature with no tested fallback is "not considered complete" per Article XI.5
+    Exception: this is the ONLY Blocking-severity check Sibyl owns; it maps the report status to BLOCKED
+```
+
+---
+
+## Output: RAG Readiness Report
+
+Sibyl emits an advisory report (mirrors the Demeter/Aegis report shape but recommends rather than refuses). The single policy-refusal analogue is the XI.5 fallback gate (`Blocking` → `BLOCKED`).
+
+```markdown
+## RAG Readiness Report
+**Project**: [project name]
+**Date**: [ISO-8601 timestamp]
+**Specialist**: Sibyl
+**Schema**: ai-native-rag
+**Declared tier**: T1 / T2 / T3 / null
+**Scope**: [layers / pipeline reviewed]
+
+---
+
+### Summary
+
+| Severity | Count |
+|---|---|
+| Blocking | N |
+| Concern | N |
+| Advisory | N |
+| Cleared | N |
+
+**Overall status**: BLOCKED / TUNING-NEEDED / READY
+(BLOCKED = any Blocking finding — i.e. the XI.5 mandatory-fallback gate K2-RULE-006 fails;
+TUNING-NEEDED = any unresolved Concern; READY = Advisory or Cleared only)
+
+---
+
+### Findings
+
+#### [SEVERITY] K2-RULE-NNN: [Title]
+**Category**: embeddings-retrieval / hnsw-tuning / mcp-hardening / prompt-audit-fallback
+**Location**: [file:line or component reference]
+**Evidence**:
+```
+[exact SQL, config line, tool signature, or gateway call site]
+```
+**Recommendation**: [specific, actionable tuning step — cites the b7-standard]
+**Verification**: [how to confirm the fix — typically an eval-set delta or a fallback test]
+
+---
+
+#### [BLOCKING] K2-RULE-006: Mandatory non-AI fallback missing / untested
+**Category**: prompt-audit-fallback
+**Location**: `backend/.../generate.rs` (LLM gateway call site, no fallback test)
+**Evidence**:
+```
+gateway.complete(prompt).await?  // no fallback path; no test mocks the AI to fail
+```
+**Recommendation**: define + test the non-AI fallback per Article XI.5 (RAG returns ranked source documents); wire the kill switch + budget to degrade to it, not hard-fail.
+**Verification**: a test exercises the fallback with the AI mocked to fail; `llm-gateway.md` § Budgets/kill switch/fallback satisfied.
+
+---
+
+### Cleared Items
+
+The following checklist items were verified clean:
+- ✓ Hybrid retrieval (pgvector + `ts_rank` fused via RRF) present
+- ✓ Embedding model tier-gated (Mistral-on-Scaleway at T3)
+- ✓ Prompt-audit span emits model/tenant/tier/tokens/latency/provider/fallback-flag
+- ...
+```
+
+---
+
+## Recommendation Catalogue
+
+Severity vocabulary (advisory agent — softer than the J8/K3 policy-refusal ladders): `Advisory` (tuning suggestion) < `Concern` (should-fix before production) < `Blocking` (the XI.5 fallback gate only — the one case that maps the report status to `BLOCKED`). This deliberately differs from Demeter's Critical/High/Medium/Low/Informational ladder because Sibyl recommends, it does not refuse.
+
+| Rule ID | Title | Trigger | Severity | Evidence pattern | Recommendation | Source |
+|---|---|---|---|---|---|---|
+| **K2-RULE-001** | Embedding model not tier-gated | OpenAI-direct (or Vertex/Bedrock) embeddings declared at compliance tier T3 | `Concern` | provider config wiring OpenAI-direct at T3 | switch to a self-hosted model or Mistral-on-Scaleway | `rag-patterns.md` § EU sovereignty / FR-K2-PYT-120 (cross-links the I.3 `forbidden-components` linter, the blocking enforcement) |
+| **K2-RULE-002** | HNSW `ef_search` untuned / no eval set | pgvector HNSW index in use, `ef_search` at default AND no labelled eval set present | `Advisory` | `ef_search` default + missing eval set | build a labelled retrieval eval set; tune `ef_search` for recall@k vs latency — emits `[NEEDS CLARIFICATION:]` not a fabricated number | `rag-patterns.md` § pgvector HNSW tuning / FR-K2-PYT-121 |
+| **K2-RULE-003** | Pure-vector retrieval (no hybrid) | retrieval uses pgvector similarity only, no full-text / RRF fusion | `Advisory` | no `ts_rank` + RRF fusion in the query path | add hybrid search + RRF for keyword-heavy / out-of-distribution recall | `rag-patterns.md` § Retrieval / FR-K2-PYT-122 |
+| **K2-RULE-004** | MCP tool over-privileged | a tool exposes >1 capability, shells out, evals, or uses a path argument verbatim | `Concern` | multi-capability tool / shell-out / verbatim path | split into one-capability tools; validate inputs against the derived `JsonSchema`; resolve paths against an allow-list | `mcp-servers.md` § Security / FR-K2-PYT-123 |
+| **K2-RULE-005** | Prompt-audit span missing | an LLM gateway call path emits no prompt-audit record | `Concern` | gateway call with no audit span (model/tenant/tier/tokens/latency/fallback) | emit the prompt-audit span per IX.6; redact PII (XI.6) | `llm-gateway.md` § Prompt audit & observability + Article IX.6 / FR-K2-PYT-124 |
+| **K2-RULE-006** | Mandatory fallback missing / untested | an LLM-backed feature has no defined non-AI fallback, OR a fallback exists but no test exercises it with the AI mocked to fail | `Blocking` | gateway call with no fallback path / no fallback test | define + test the non-AI fallback (RAG returns ranked source documents); wire kill switch + budget to degrade to it, not hard-fail | `llm-gateway.md` § Budgets/kill switch/fallback + Article XI.5 / FR-K2-PYT-125 |
+
+**Numbering invariant** (per ADR-J8-004 inheritance): IDs are NEVER reused. A decommissioned rule is marked `DEPRECATED`; the slot is not recycled. Future K.2 extensions append `K2-RULE-007..`. The `K2-RULE-*` namespace is syntactically disjoint from `J8-RULE-*` (Janus forbidden catalogue) and `K3-RULE-*` (Demeter) per FR-K2-PYT-086.
+
+**Why only one `Blocking` rule**: Sibyl is advisory. Tuning `ef_search`, adding hybrid retrieval, or splitting an MCP tool are recommendations the adopter weighs against their workload. The single non-negotiable is the Article XI.5 mandatory fallback — a feature that cannot degrade off the AI path is, by constitutional definition, not complete.
+
+---
+
+## Integration
+
+### Janus Step 3 dispatch (ai-native-rag)
+
+Janus dispatches Sibyl at **Step 3 — Parallel Design Dispatch** of the cross-layer 12-step workflow, for projects whose root `.forge.yaml` declares `schema: ai-native-rag`. Sibyl advises the per-layer RAG / LLM-gateway / MCP design (the AI-pipeline specialist pass) and returns a `RAG Readiness Report`. A `Blocking` finding (K2-RULE-006, the XI.5 fallback gate) blocks progression to Step 4 — analogous to a `[NEEDS CLARIFICATION]` on a missing per-layer design. Sibyl is dispatched at the **design** pass (Step 3), NOT the Step 9 security/data-stewardship pass (that is Aegis + Demeter). See `.claude/agents/cross-layer-orchestrator.md` Step 3 narrative + the Dispatch Table row.
+
+### Relationship to Oracle (AI-First Brainstorm)
+
+Oracle defines the AI capability + the mandatory fallback at proposal/brainstorm time; Sibyl tunes the *realised* pipeline at design/review time. Disjoint phases — Oracle precedes the layer orchestrators, Sibyl reviews their output. Oracle says "this feature uses RAG with a source-document fallback"; Sibyl says "the `ef_search` is untuned and the fallback has no test".
+
+### Relationship to Demeter (K.3)
+
+Demeter owns dependency-jurisdiction + DPA + tier classification; Sibyl owns AI-pipeline tuning + prompt-audit + fallback. Disjoint surfaces: Demeter does NOT tune `ef_search`; Sibyl does NOT scan `Cargo.lock` jurisdiction. Both may advise on the same `ai-native-rag` change without overlap — Demeter at Step 9, Sibyl at Step 3.
+
+### Relationship to Vulcan / Hera (layer orchestrators)
+
+Sibyl *advises*; Vulcan (Rust backend — RAG pipeline, LLM gateway, MCP servers) and Hera (Qwik frontend) *implement*. Sibyl writes no application code; its output is a `RAG Readiness Report` the orchestrators act on.
+
+### Standards consumed (not amended)
+
+- `.forge/standards/global/rag-patterns.md` (B.7.3) — chunking/embeddings, hybrid retrieval + RRF, pgvector HNSW `ef_search` tuning, re-ranking, EU sovereignty. Operationalised by the Embeddings & Retrieval + pgvector HNSW Tuning checklists.
+- `.forge/standards/global/llm-gateway.md` (B.7.3) — prompt audit (IX.6), budgets/kill-switch, mandatory fallback (XI.5), PII (XI.6). Operationalised by the Prompt Audit & Fallback checklist.
+- `.forge/standards/global/mcp-servers.md` (B.7.3) — rmcp server pattern, least-privilege security, OAuth 2.1 → Zitadel/Envoy. Operationalised by the MCP Server Hardening checklist.
+- `.forge/standards/global/compliance-tiers.md` (I.2) + `.forge/standards/global/forbidden-components-rules.md` (I.3) — REFERENCED for the tier-aware posture (K2-RULE-001); not restated, not edited.
+
+Sibyl authors NO new standard (ADR-K2-005 / FR-K2-PYT-081) and ships NO scanner or data file (ADR-K2-003 / NFR-K2-PYT-002). It owns the three b7-standards by reference — by being the named specialist the `index.yml` triggers route to.
+
+---
+
+## Anti-Hallucination Protocol
+
+Sibyl operates under the Article III.4 contract verbatim. The protocol surfaces in three concrete situations:
+
+1. **No eval set to tune against**: a pgvector HNSW index is in use with default `ef_search` but no labelled retrieval eval set is present. Sibyl MUST emit `[NEEDS CLARIFICATION: no labelled eval set — cannot tune ef_search without recall@k targets]` rather than a fabricated number (K2-RULE-002, `Advisory`). It NEVER invents an `ef_search` value, a chunk size, or a recall@k target.
+
+2. **Undeclared embedding model**: the pipeline does not declare which embedding model produces the vectors, so normalisation, distance op, and tier-gating cannot be advised. Sibyl MUST emit `[NEEDS CLARIFICATION: embedding model undeclared — cannot advise normalisation / distance op / tier-gating]` and STOP.
+
+3. **Undeclared compliance tier**: neither the root `.forge.yaml` nor a tier ledger declares the compliance tier that gates the provider, so K2-RULE-001 cannot fire deterministically. Sibyl MUST emit `[NEEDS CLARIFICATION: compliance tier undeclared — cannot gate the embedding/LLM provider]` and STOP. No default tier is inferred.
+
+The clarification markers feed the per-change `open-questions.md` ledger when Sibyl is dispatched within a `.forge/changes/<name>/` workflow. Sibyl never silently proceeds with a guessed tuning value.
+
+**Privacy invariant** (Article XI.6): Sibyl reviews pipeline *structure* (chunking strategy, audit-span coverage, fallback presence), not user data. The prompt-audit + embeddings checklists assert PII minimisation before chunks reach a provider; Sibyl reads no actual PII.
+
+---
+
+## Audit cross-references
+
+This persona is justified by the following upstream sources, cited verbatim per FR-K2-PYT-011:
+
+- `docs/new-archetypes-plan.md` §9 line 2665 — K.2 row in the K-modules table (Pythia/AI-RAG responsibilities: embeddings, pgvector tuning HNSW `ef_search`, MCP servers, prompt audit; archetype scope `ai-native-rag`).
+- `docs/new-archetypes-plan.md` §6.2 line 2585 — B.7.4 (the §6.2 plan item mandating the AI/RAG agent for `ai-native-rag`).
+- `docs/new-archetypes-plan.md` §0.12 brick table line 2022 — brick #4 (`b7-pythia`, patron `k3-demeter`).
+- `docs/ARCHITECTURE-TARGET.md` §9.2 line 727 — the AI/RAG specialist agent introduction in the post-v0.3.0 architecture.
+- `.forge/standards/global/rag-patterns.md` + `.forge/standards/global/llm-gateway.md` + `.forge/standards/global/mcp-servers.md` (B.7.3) — the three standards Sibyl owns by reference / consumes.
+
+> Persona name **Sibyl** ratified by the maintainer 2026-06-22 (ADR-K2-001, Q-001 Option B). The brick name stays `b7-pythia` (it names the roadmap K.2 row, not the persona). The existing Product-Analyst-Pythia (`.claude/agents/product-analyst.md`) is a separate, untouched agent.

--- a/.forge/changes/b7-pythia/.forge.yaml
+++ b/.forge/changes/b7-pythia/.forge.yaml
@@ -1,0 +1,29 @@
+name: b7-pythia
+status: planned
+created: 2026-06-22
+schema: default
+constitution_version: "2.0.0"
+parent_audit_items:
+  - K.2     # docs/new-archetypes-plan.md §9 line 2665 — Pythia (AI/RAG) specialist agent
+  - B.7.4   # docs/new-archetypes-plan.md §6.2 line 2585 — Pythia agent for ai-native-rag
+depends_on:
+  - b7-standards    # global/{rag-patterns,llm-gateway,mcp-servers}.md — the standards Pythia owns/consumes
+  - b7-2-scaffolder # templates/ai-native-rag/1.0.0/* — the RAG pipeline / LLM gateway / MCP stubs Pythia tunes
+  - k3-demeter      # precedent layout (persona + Janus delta + harness + CLAUDE.md row) + <MODULE>-RULE-NNN namespace
+  - j8-janus-rules  # ADR-J8-004 rule-ID format inherited by K2-RULE-*
+# BLOCKED on Q-001 — persona name collision with existing Product-Analyst-Pythia.
+#   Maintainer ratification of ADR-K2-001 required before /forge:implement.
+#   Tracked in open-questions.md (Status: open, BLOCKING). The change.schema.json
+#   closed shape has no `blocked_on` field, so this is recorded as a comment +
+#   the timeline below intentionally stops at `planned` (no implemented/archived).
+# COLLISION with sibling brick b7-9-janus-ai — co-edits cross-layer-orchestrator.md
+#   + CLAUDE.md in DISJOINT sections (Pythia → Dispatch Table + Step 3 + Quality
+#   Gates ; b7-9 → Forbidden-archetypes/J8-RULE catalogue). See design.md
+#   § "Shared-file collision with sibling bricks".
+timeline:
+  proposed: 2026-06-22
+  specified: 2026-06-22
+  designed: 2026-06-22
+  planned: 2026-06-22
+  # implemented: <pending — BLOCKED on Q-001 ratification>
+  # archived: <pending>

--- a/.forge/changes/b7-pythia/.forge.yaml
+++ b/.forge/changes/b7-pythia/.forge.yaml
@@ -1,5 +1,5 @@
 name: b7-pythia
-status: planned
+status: implemented
 created: 2026-06-22
 schema: default
 constitution_version: "2.0.0"
@@ -11,11 +11,11 @@ depends_on:
   - b7-2-scaffolder # templates/ai-native-rag/1.0.0/* — the RAG pipeline / LLM gateway / MCP stubs Pythia tunes
   - k3-demeter      # precedent layout (persona + Janus delta + harness + CLAUDE.md row) + <MODULE>-RULE-NNN namespace
   - j8-janus-rules  # ADR-J8-004 rule-ID format inherited by K2-RULE-*
-# BLOCKED on Q-001 — persona name collision with existing Product-Analyst-Pythia.
-#   Maintainer ratification of ADR-K2-001 required before /forge:implement.
-#   Tracked in open-questions.md (Status: open, BLOCKING). The change.schema.json
-#   closed shape has no `blocked_on` field, so this is recorded as a comment +
-#   the timeline below intentionally stops at `planned` (no implemented/archived).
+# Q-001 (persona name collision) RESOLVED 2026-06-22 — maintainer ratified
+#   Option B, name "Sibyl" (ADR-K2-001 / open-questions.md Q-001 Resolution).
+#   Persona = .claude/agents/sibyl.md ; the shipped Product-Analyst-Pythia is
+#   untouched. Q-002 + Q-003 answered via ADR-K2-002 / ADR-K2-003. The change is
+#   now `implemented` ; archival is a separate pass (orchestrator verifies).
 # COLLISION with sibling brick b7-9-janus-ai — co-edits cross-layer-orchestrator.md
 #   + CLAUDE.md in DISJOINT sections (Pythia → Dispatch Table + Step 3 + Quality
 #   Gates ; b7-9 → Forbidden-archetypes/J8-RULE catalogue). See design.md
@@ -25,5 +25,5 @@ timeline:
   specified: 2026-06-22
   designed: 2026-06-22
   planned: 2026-06-22
-  # implemented: <pending — BLOCKED on Q-001 ratification>
-  # archived: <pending>
+  implemented: 2026-06-22
+  # archived: <pending — STOP before archive ; orchestrator verifies independently>

--- a/.forge/changes/b7-pythia/.forge.yaml
+++ b/.forge/changes/b7-pythia/.forge.yaml
@@ -1,5 +1,5 @@
 name: b7-pythia
-status: implemented
+status: archived
 created: 2026-06-22
 schema: default
 constitution_version: "2.0.0"
@@ -11,6 +11,8 @@ depends_on:
   - b7-2-scaffolder # templates/ai-native-rag/1.0.0/* — the RAG pipeline / LLM gateway / MCP stubs Pythia tunes
   - k3-demeter      # precedent layout (persona + Janus delta + harness + CLAUDE.md row) + <MODULE>-RULE-NNN namespace
   - j8-janus-rules  # ADR-J8-004 rule-ID format inherited by K2-RULE-*
+archived_to:
+  - .forge/specs/ai-native-rag.md  # K.2 ADDED block (FR-K2-PYT-* / NFR-K2-PYT-* / ADR-K2-*) appended at archive ; prior B.7 blocks preserved
 # Q-001 (persona name collision) RESOLVED 2026-06-22 — maintainer ratified
 #   Option B, name "Sibyl" (ADR-K2-001 / open-questions.md Q-001 Resolution).
 #   Persona = .claude/agents/sibyl.md ; the shipped Product-Analyst-Pythia is
@@ -26,4 +28,4 @@ timeline:
   designed: 2026-06-22
   planned: 2026-06-22
   implemented: 2026-06-22
-  # archived: <pending — STOP before archive ; orchestrator verifies independently>
+  archived: 2026-06-22

--- a/.forge/changes/b7-pythia/design.md
+++ b/.forge/changes/b7-pythia/design.md
@@ -32,6 +32,16 @@ specialist **Delphi** (the oracle's seat — thematically a retrieval site).
 - The brick / change name stays **`b7-pythia`** regardless (it documents the
   roadmap K.2 "Pythia" row ; the persona's final name is independent).
 
+> **RATIFIED 2026-06-22 (Q-001 Resolution, `open-questions.md`)** : the
+> maintainer chose **Option B** and selected the name **Sibyl** (a Greek
+> prophetess/seer) over this ADR's recommended "Delphi". The ratified binding —
+> which **supersedes the "Delphi" recommendation above** — is :
+> - Persona file : `.claude/agents/sibyl.md`.
+> - H1 : `# Agent: AI/RAG Specialist (Sibyl)`.
+> - The shipped Product-Analyst-Pythia (`.claude/agents/product-analyst.md`) and
+>   its 4 references are **not** modified (zero churn).
+> - The brick / change name stays `b7-pythia`.
+
 **Why Option B over A** : renaming a shipped, 4-file-referenced persona (Option
 A) is higher churn + higher regression risk than naming a brand-new agent. The
 roadmap "Pythia (AI/RAG)" is a label, not a contract ; the documentary link to

--- a/.forge/changes/b7-pythia/design.md
+++ b/.forge/changes/b7-pythia/design.md
@@ -1,0 +1,478 @@
+# Design: b7-pythia
+
+<!-- Status: designed -->
+<!-- Schema: default -->
+
+> Read alongside `specs.md` (FR-K2-PYT-* / NFR-K2-PYT-*) and `open-questions.md`
+> (Q-001 BLOCKING + Q-002 + Q-003). This document locks the implementation
+> strategy for the K.2 Pythia AI/RAG specialist agent and resolves Q-002 + Q-003
+> via ADR-K2-002 + ADR-K2-003. **Q-001 (name collision) is recorded as
+> ADR-K2-001 with a recommended default but requires maintainer ratification
+> before the change may flip to `implemented`** (Article III.4).
+
+## Architecture Decisions
+
+### ADR-K2-001 — Persona name & file path (records Q-001 ; maintainer-gated)
+
+**Context** : the roadmap (§9 line 2665, §6.2 line 2585) names the K.2 AI/RAG
+agent **Pythia**, but `.claude/agents/product-analyst.md` already declares
+`# Agent: Product Analyst (Pythia)` and four files bind that name to the Product
+Analyst (`forge-master.md` lines 39/143, `product-analyst.md`,
+`commands/forge/onboard.md` line 54, `commands/forge/propose.md` line 31).
+Name-based dispatch cannot disambiguate two "Pythia" agents.
+
+**Decision** : the persona name is **parameterised** (`<pythia-name>`) through
+specs + tasks until the maintainer ratifies one of the Q-001 options. The
+**recommended default** (encoded here, not yet locked) is **Option B**: keep
+"Pythia" for the already-shipped Product Analyst; name the new K.2 AI/RAG
+specialist **Delphi** (the oracle's seat — thematically a retrieval site).
+
+- Persona file (recommended) : `.claude/agents/delphi.md`.
+- H1 (recommended) : `# Agent: AI/RAG Specialist (Delphi)`.
+- The brick / change name stays **`b7-pythia`** regardless (it documents the
+  roadmap K.2 "Pythia" row ; the persona's final name is independent).
+
+**Why Option B over A** : renaming a shipped, 4-file-referenced persona (Option
+A) is higher churn + higher regression risk than naming a brand-new agent. The
+roadmap "Pythia (AI/RAG)" is a label, not a contract ; the documentary link to
+the roadmap row is preserved by the brick name.
+
+**Rejected** : Option C (placeholder name on disk) — leaves an unnamed agent,
+violates the spirit of a "first-class agent persona" (XI.1).
+
+**Consequences** :
+- ✅ Zero churn on the shipped Product Analyst (Option B).
+- ✅ Harness is name-agnostic (NFR-K2-PYT-007) — it resolves the agent path from
+  a single `PYTHIA_AGENT` variable, so the suite passes the moment the ADR locks
+  the value, with no per-test edit.
+- ⚠️ **BLOCKING** : the literal name is NOT locked by this design ; it is a
+  maintainer call (touches a shipped persona's identity + the roadmap's stated
+  name). The change MUST NOT flip to `implemented` until the maintainer ratifies
+  ADR-K2-001's name. Recorded in `open-questions.md` Q-001 ; the `verify` /
+  archival gate checks Q-001 status is `answered`.
+
+**Constitution Compliance** : Article III.4 (never guess a contested name),
+XI.1 (agent-native — the agent IS named, just pending ratification). No
+violation.
+
+---
+
+### ADR-K2-002 — K2-RULE namespace : 6 seed rules, incremental growth (resolves Q-002)
+
+**Context** : Q-002 weighed pre-allocation vs incremental growth for the
+`K2-RULE-NNN` catalogue. ADR-J8-004 locked the `<MODULE>-RULE-NNN` format ;
+ADR-K3-005 chose incremental growth for K3-RULE.
+
+**Decision** : **incremental growth, 6 seed rules**, mirroring ADR-K3-005. Seed
+catalogue (one per checklist area + the XI.5 fallback gate) :
+
+- **K2-RULE-001** — Embedding model not tier-gated (`Concern`, FR-K2-PYT-120).
+- **K2-RULE-002** — HNSW `ef_search` untuned / no eval set (`Advisory`,
+  FR-K2-PYT-121 ; emits `[NEEDS CLARIFICATION:]` not a fabricated number).
+- **K2-RULE-003** — Pure-vector retrieval, no hybrid (`Advisory`, FR-K2-PYT-122).
+- **K2-RULE-004** — MCP tool over-privileged (`Concern`, FR-K2-PYT-123).
+- **K2-RULE-005** — Prompt-audit span missing / IX.6 (`Concern`, FR-K2-PYT-124).
+- **K2-RULE-006** — Mandatory fallback missing / untested / XI.5 (`Blocking` —
+  the single Blocking rule, FR-K2-PYT-125).
+
+**Severity vocabulary** (advisory agent — softer than J8/K3 policy-refusal) :
+`Advisory` (tuning suggestion) < `Concern` (should-fix before production) <
+`Blocking` (XI.5 fallback gate only ; the one case that maps the report status
+to `BLOCKED`). This differs deliberately from Demeter's
+Critical/High/Medium/Low/Informational ladder because Pythia recommends, it does
+not refuse.
+
+**Numbering invariant** (per ADR-J8-004 inheritance) : IDs NEVER reused ; future
+K.2 extensions append `K2-RULE-007..` ; decommissioned rules marked
+`DEPRECATED`, slot not recycled.
+
+**Consequences** :
+- ✅ Spec discipline preserved ; 6 rules cover the 3 BDD scenarios + the four
+  checklist areas.
+- ✅ `K2-RULE-*` is syntactically disjoint from `J8-RULE-*` / `K3-RULE-*`
+  (FR-K2-PYT-086).
+
+**Constitution Compliance** : Article V (audit trail). No violation.
+
+---
+
+### ADR-K2-003 — Advisory agent, NO scanner (resolves Q-003 ; principal divergence from k3-demeter)
+
+**Context** : the brick's stated patron `k3-demeter` ships a deterministic
+scanner (`bin/forge-demeter-scan.sh` + `cloud-act-publishers.yml` deny-list +
+JSON-report exit-code contract). Q-003 asks whether Pythia mirrors that.
+
+**Decision** : **NO scanner. Pythia is a pure advisory / tuning specialist**, in
+the `observability-specialist.md` (Panoptes) mould — persona checklists + a
+`RAG Readiness Report` template + a `K2-RULE-*` recommendation catalogue, and
+**nothing executable**.
+
+**Rationale** :
+1. The plan §9 K.2 verbs are advisory : *"tune pgvector (HNSW `ef_search`), MCP
+   servers, prompt audit"*.
+2. HNSW / embeddings tuning is **inherently workload-specific and
+   non-deterministic** — `ef_search` is tuned against the adopter's labelled eval
+   set, which a generic scanner cannot synthesise. A scanner that guessed a
+   number would violate Article III.4 (FR-K2-PYT-008 / K2-RULE-002 emit
+   `[NEEDS CLARIFICATION:]` precisely because there is no deterministic answer).
+3. The prompt-audit + fallback checks are design/review-time gates Janus already
+   dispatches (FR-K2-PYT-083) — not a standalone CLI surface.
+4. Demeter's scanner is justified because CLOUD Act jurisdiction is a
+   *deterministic deny-list lookup* ; Pythia's domain has no analogous
+   deterministic oracle.
+
+**What this removes vs the k3-demeter precedent** (all explicitly out of scope) :
+`bin/forge-pythia-scan.sh`, the Python engine, `.forge/data/*.yml`, the
+exit-code 0/1/2/3 contract, the `SOURCE_DATE_EPOCH` reproducibility NFR, the
+deny-list-hit L2 fixture. The harness's single L2 fixture instead asserts
+persona-anchor integrity across a fresh checkout (FR-K2-PYT / NFR-K2-PYT-007).
+
+**Consequences** :
+- ✅ Smaller, honest surface — no false-confidence scanner.
+- ✅ NFR-K2-PYT-002 (no executable) is a first-class guard.
+- ⚠️ Reviewers expecting a 1:1 k3-demeter mirror must read this ADR ; the
+  divergence is deliberate and the plan's K.2 verbs justify it. Flagged at the
+  top of `tasks.md` and in the proposal Scope Out.
+
+**Constitution Compliance** : Article VIII (no service / no daemon — trivially
+satisfied, there is no executable), XI.1 (agent-native persona). No violation.
+
+---
+
+### ADR-K2-004 — Janus integration : Dispatch-Table row + Step 3 design-pass note (delta-based, Article IV.1)
+
+**Context** : FR-K2-PYT-082 + FR-K2-PYT-083 require a Janus Dispatch-Table row +
+a workflow-pass integration. Article IV.1 requires delta-based modifications.
+`cross-layer-orchestrator.md` is **co-edited by `b7-9-janus-ai`** — the deltas
+must be disjoint (see § "Shared-file collision" below).
+
+**Decision** : two surgical edits to
+`.claude/agents/cross-layer-orchestrator.md`, both in sections **disjoint** from
+`b7-9-janus-ai`'s J8-RULE forbidden-catalogue edits :
+
+1. **Dispatch Table row** — inserted **after** the Demeter row (the current last
+   row of the table at line 32) and **before** the closing `---` (line 34) :
+   ```markdown
+   | AI/RAG specialist work on `ai-native-rag` — embeddings/retrieval tuning, pgvector HNSW `ef_search`, MCP server hardening, prompt-audit + mandatory-fallback gates | **<Pythia-Name>** (AI/RAG Specialist) | <Pythia-Name> drives AI-pipeline tuning + prompt-audit/fallback review for `ai-native-rag` cross-layer changes ; advisory, complementary to Demeter's data-stewardship and Aegis's vulnerability passes. |
+   ```
+
+2. **Step 3 design-pass note** (NOT Step 9) — append a single paragraph to the
+   `### Step 3 — Parallel Design Dispatch` H3 stating : *for projects whose root
+   `.forge.yaml` declares `schema: ai-native-rag`, Janus additionally briefs
+   `<Pythia-Name>` to advise the per-layer RAG / LLM-gateway / MCP design (the
+   AI-pipeline specialist pass), and collects a `RAG Readiness Report` whose
+   `Blocking` findings (K2-RULE-006 XI.5 fallback gate) block progression to
+   Step 4 — analogous to a `[NEEDS CLARIFICATION]` on a missing per-layer
+   design.* Plus a one-bullet entry in the **Quality Gates** H2 : *"AI/RAG
+   readiness gate — dispatched to **<Pythia-Name>** for `ai-native-rag` projects ;
+   a `Blocking` (XI.5 fallback) finding blocks the change."*
+
+**Why Step 3 (design dispatch), not Step 9 (security/data-stewardship)** : Step 9
+is the Aegis+Demeter security/data-stewardship pass (already extended by K.3).
+Pythia's work is **AI-pipeline design tuning**, which belongs with the per-layer
+design dispatch (Step 3), not the security pass. Keeping Pythia out of Step 9
+also keeps the K.3 Step 9 narrative untouched (no regression to the Demeter
+delta) and keeps a clean disjoint boundary from `b7-9-janus-ai`.
+
+**Constitution compliance** H2 of `cross-layer-orchestrator.md` MAY gain a
+one-bullet AI-First entry (Article XI — `<Pythia-Name>` has reviewed the
+AI-pipeline tuning + mandatory fallback). Article reference (XI.5 + IX.6) locked
+at impl.
+
+**Consequences** :
+- ✅ Article IV.1 delta-based modification respected ; the 12-step shape
+  preserved (only Step 3 gains a conditional AI-pipeline note).
+- ✅ Disjoint from K.3 Step 9 and from `b7-9-janus-ai`'s Forbidden-catalogue.
+- ⚠️ Whichever brick lands second (b7-pythia or b7-9-janus-ai) rebases its
+  surgical delta. The deltas touch different H2/H3 sections so a textual merge is
+  clean. See § collision.
+
+**Constitution Compliance** : Articles IV.1, V (audit trail via Dispatch Table +
+Step 3 note + Quality Gates bullet). No violation.
+
+---
+
+### ADR-K2-005 — Standards-index : additive triggers, NO new entry (resolves FR-K2-PYT-080)
+
+**Context** : K.3 authored a brand-new standard (`data-stewardship-rules.md`) +
+a new `index.yml` entry. Pythia owns three **pre-existing** standards
+(`b7-standards`). It must be discoverable without re-authoring them.
+
+**Decision** : **additive `triggers:` edit only** to the three existing B.7.3
+`index.yml` entries (lines ~439-455). Add the keyword `pythia` (and the recommended
+final name, e.g. `delphi`, once ADR-K2-001 locks it) to each of
+`global/rag-patterns`, `global/llm-gateway`, `global/mcp-servers`; add
+`ef-search` / `embeddings-tuning` to `rag-patterns` specifically. **No new
+`index.yml` entry**, **no new standard file** (FR-K2-PYT-081).
+
+Example (post-edit `rag-patterns` triggers) :
+```yaml
+triggers: [rag, retrieval, embeddings, pgvector, hnsw, ef-search, embeddings-tuning, re-ranking, hybrid-search, vector-search, ai-native-rag, chunking, context-window, pythia]
+```
+
+**Why additive, not a new entry** : the standards already exist and already map
+1:1 to the schema components. Pythia "owns" them by being the named specialist
+the triggers route to — a new index entry pointing at the same files would
+duplicate. Additivity keeps `validate-standards-yaml.sh` / `j7` GREEN
+(NFR-K2-PYT-005) because the entry shape is unchanged (only an array grows).
+
+**Consequences** :
+- ✅ Minimal, non-duplicating ; no standard content edited (NFR-K2-PYT-004).
+- ✅ J.7 validation unaffected (array extension, not schema change).
+- ✅ Diverges cleanly from K.3 (which DID need a new standard) — divergence
+  justified because the standards pre-exist.
+
+**Constitution Compliance** : Article XII (governance — consumes standards, does
+not amend), III.4 (no fabricated standard filename). No violation.
+
+---
+
+## Component Design
+
+```mermaid
+classDiagram
+    class pythia_md {
+        +Persona[name pending ADR-K2-001]
+        +Purpose[K.2 + B.7.4 + 3 b7-standards]
+        +Checklists[Embeddings&Retrieval | HNSW Tuning | MCP Hardening | PromptAudit&Fallback]
+        +Output RAG Readiness Report
+        +Recommendation Catalogue[K2-RULE-001..006]
+        +Integration[Janus Step3 | Oracle | Demeter | Vulcan/Hera]
+        +Anti-Hallucination Protocol
+        +Audit cross-references
+    }
+    class rag_patterns_md {
+        <<existing b7-standards>>
+        +chunking/embeddings
+        +hybrid retrieval + RRF
+        +HNSW ef_search tuning
+        +re-ranking
+        +EU sovereignty
+    }
+    class llm_gateway_md {
+        <<existing b7-standards>>
+        +proxy architecture
+        +tier-aware refusal
+        +prompt audit IX.6
+        +budgets/kill-switch/fallback XI.5
+    }
+    class mcp_servers_md {
+        <<existing b7-standards>>
+        +rmcp server pattern
+        +least-privilege security
+        +OAuth 2.1 -> Zitadel
+    }
+    class janus_md {
+        +Dispatch Table (+Pythia row)
+        +Step 3 (+AI-pipeline design note)
+        +Quality Gates (+AI/RAG readiness gate)
+    }
+    class standards_index_yml {
+        +rag-patterns triggers +pythia/+ef-search
+        +llm-gateway triggers +pythia
+        +mcp-servers triggers +pythia
+    }
+    class claude_md {
+        +AI/RAG specialist trigger row
+    }
+    class b7_pythia_test_sh {
+        +L1 tests[grep anchors]
+        +L2 fixture[fresh-checkout anchor integrity]
+    }
+
+    pythia_md --> rag_patterns_md : consumes
+    pythia_md --> llm_gateway_md : consumes
+    pythia_md --> mcp_servers_md : consumes
+    janus_md --> pythia_md : dispatches Step 3 (ai-native-rag)
+    standards_index_yml --> rag_patterns_md : triggers route to pythia
+    claude_md --> pythia_md : trigger row
+    b7_pythia_test_sh --> pythia_md : grep anchors
+    b7_pythia_test_sh --> janus_md : asserts dispatch row
+    b7_pythia_test_sh --> standards_index_yml : asserts pythia trigger
+```
+
+## Data Flow — Janus dispatches Pythia at Step 3 (ai-native-rag, fallback untested)
+
+```mermaid
+sequenceDiagram
+    participant J as Janus
+    participant V as Vulcan (backend)
+    participant H as Hera (frontend)
+    participant P as <Pythia-Name>
+    participant RP as rag-patterns.md
+    participant LG as llm-gateway.md
+
+    J->>V: Step 3 — backend RAG/LLM/MCP design dispatch
+    J->>H: Step 3 — frontend Qwik UI design dispatch
+    J->>P: Step 3 — AI/RAG specialist pass (schema: ai-native-rag)
+    P->>RP: load chunking/HNSW/hybrid patterns
+    P->>LG: load prompt-audit + fallback patterns
+    P->>P: run Embeddings/HNSW/MCP/PromptAudit checklists
+    Note over P: feature calls LLM gateway, no tested non-AI fallback
+    P->>P: K2-RULE-006 Blocking (XI.5 fallback missing)
+    P-->>J: RAG Readiness Report — overall_status BLOCKED
+    Note over J: Blocking finding blocks progression to Step 4<br/>routed back to Vulcan to add + test the fallback
+```
+
+## Test Harness Design
+
+`.forge/scripts/tests/b7-pythia.test.sh` mirrors the `k3.test.sh` layout (bash
+header, `_helpers.sh` source, PASS/FAIL counters, `--level 1,2` parsing,
+`print_summary`) **minus the scanner machinery** (ADR-K2-003). It resolves the
+agent path from a single `PYTHIA_AGENT` variable (NFR-K2-PYT-007) so it is
+name-agnostic until ADR-K2-001 locks the value.
+
+### L1 — anchor-level (≥ 14 grep tests)
+
+| Test ID                                  | FR covered                | Anchor asserted                                                                          |
+|------------------------------------------|---------------------------|------------------------------------------------------------------------------------------|
+| `_test_b7p_001_persona_exists`           | FR-K2-PYT-001             | `$PYTHIA_AGENT` file exists                                                               |
+| `_test_b7p_002_audit_comment`            | FR-K2-PYT-010             | `<!-- Audit: K.2 (b7-pythia) -->` + `<!-- Audit: B.7.4 (b7-pythia) -->` in first 6 lines |
+| `_test_b7p_003_persona_h2`               | FR-K2-PYT-002 / 003       | `## Persona` + `## Purpose` H2 anchors                                                    |
+| `_test_b7p_004_checklists_h2`            | FR-K2-PYT-004             | `## Checklists` H2 + 4 H3 (Embeddings & Retrieval / pgvector HNSW Tuning / MCP Server Hardening / Prompt Audit & Fallback) |
+| `_test_b7p_005_checklists_items`         | FR-K2-PYT-004             | each of the 4 H3 has ≥ 5 `[ ]` items                                                     |
+| `_test_b7p_006_output_h2`                | FR-K2-PYT-005             | `## Output: RAG Readiness Report` H2 + Summary table (`\| Severity \|`)                   |
+| `_test_b7p_007_rule_catalogue`           | FR-K2-PYT-006 / 120..125  | `## Recommendation Catalogue` H2 + K2-RULE-001..006 anchors                              |
+| `_test_b7p_008_fallback_blocking`        | FR-K2-PYT-125 / XI.5      | K2-RULE-006 present + `Blocking` severity + `XI.5` reference                              |
+| `_test_b7p_009_integration`              | FR-K2-PYT-007             | `## Integration` H2 + `cross-layer-orchestrator` ref + Oracle + Demeter mentions          |
+| `_test_b7p_010_anti_halluc`              | FR-K2-PYT-008             | `## Anti-Hallucination Protocol` H2 + `[NEEDS CLARIFICATION:` mention                     |
+| `_test_b7p_011_standards_consumed`       | FR-K2-PYT-003 / 020..027  | persona references all three : `rag-patterns` + `llm-gateway` + `mcp-servers`             |
+| `_test_b7p_012_index_triggers`           | FR-K2-PYT-080             | `index.yml` rag-patterns/llm-gateway/mcp-servers entries each contain the `pythia` trigger keyword |
+| `_test_b7p_013_no_new_standard`          | FR-K2-PYT-081             | no new `global/*.md` standard authored by this change (guard : only the 3 b7-standards exist for RAG) |
+| `_test_b7p_014_janus_dispatch_row`       | FR-K2-PYT-082             | `cross-layer-orchestrator.md` Dispatch Table contains the `<Pythia-Name>` AI/RAG row     |
+| `_test_b7p_015_janus_step3_note`         | FR-K2-PYT-083 / ADR-K2-004| `cross-layer-orchestrator.md` Step 3 H3 contains an `ai-native-rag` Pythia note (and Step 9 Demeter narrative UNCHANGED — guard) |
+| `_test_b7p_016_claude_md_trigger`        | FR-K2-PYT-084             | repo `CLAUDE.md` agent table contains the AI/RAG specialist row                          |
+| `_test_b7p_017_no_namespace_collision`   | FR-K2-PYT-086             | grep `K2-RULE` returns empty in J8-RULE / K3-RULE surfaces and vice-versa                |
+| `_test_b7p_018_no_scanner`               | NFR-K2-PYT-002 / ADR-K2-003| no `bin/forge-pythia*.sh` and no `.forge/data/pythia*.yml` exist (advisory-only guard)   |
+
+**18 L1 tests** — exceeds the precedent's ≥ 18 baseline despite the smaller
+surface (more guards because the divergences from k3-demeter — no scanner, no new
+standard, name-agnostic — each need an explicit negative test).
+
+### L2 — fixture-level (1 test)
+
+| Fixture                          | Coverage                                                                                  | Expected                                                                 |
+|----------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `_test_b7p_l2_anchor_integrity`  | copy `$PYTHIA_AGENT` into a tmpdir, run the L1 anchor greps against the copy (fresh-checkout simulation) | all H2/H3 + K2-RULE anchors present on the isolated copy ; proves the persona is self-contained, not dependent on repo-relative state |
+
+No scanner-exit-code L2 fixture (ADR-K2-003 — Pythia ships no executable). The
+single L2 fixture proves anchor integrity in isolation, the closest analogue to
+the precedent's "clean tree" reproducibility intent without an executable to run.
+
+### Performance
+
+L1 ≤ 3 s (pure grep) ; full `--level 1,2` ≤ 5 s. No Python, no cargo, no network.
+
+### CI registration
+
+`b7-pythia.test.sh --level 1,2` registered in `.github/workflows/forge-ci.yml`
+`harnesses=(...)` array, inserted **immediately after** `"b7-2.test.sh --level 1"`
+(line 126) so the B.7 chain stays contiguous and adjacency-presence assertions in
+sibling harnesses (the `grep -F '<name>.test.sh'` convention noted in the
+workflow header) hold.
+
+## Shared-file collision with sibling bricks (NFR-K2-PYT-006)
+
+Two files are co-edited by sibling brick **`b7-9-janus-ai`** (B.7.9 + J.8.c —
+runtime AI refusal rules : Vertex/Bedrock refusal, T3 ⇒ Mistral-EU/vLLM).
+
+| File | `b7-pythia` edits | `b7-9-janus-ai` edits (anticipated) | Disjoint? |
+|------|-------------------|--------------------------------------|-----------|
+| `.claude/agents/cross-layer-orchestrator.md` | **Dispatch Table** (+1 row after Demeter) ; **Step 3** H3 (+1 AI-pipeline design note) ; **Quality Gates** H2 (+1 bullet) | **Forbidden archetypes & combinations** H2 (J8-RULE-004+ AI refusal rules : Vertex/Bedrock, T3⇒Mistral-EU) ; refusal-semantics block | ✅ Yes — different H2/H3 sections. Pythia never touches the J8-RULE forbidden catalogue ; b7-9 never touches the Dispatch Table / Step 3 / Quality Gates. |
+| `CLAUDE.md` | +1 row in the agent-delegation table (AI/RAG specialist) | possible Janus-compatibility note / forbidden-archetype mention | ✅ Yes — Pythia's edit is a single delegation-table row ; b7-9's is prose elsewhere. If both touch the table, the rows are distinct and adjacent. |
+
+**Merge protocol** : whichever brick lands second rebases its surgical delta onto
+the first. Because the edits live in different sections, a textual 3-way merge is
+clean (no overlapping hunks). Both bricks MUST re-run the full harness suite
+post-merge to confirm no regression. The `b7-pythia.test.sh` guard
+`_test_b7p_015_janus_step3_note` explicitly asserts the **Step 9 Demeter
+narrative is unchanged** and does not assert anything about the Forbidden
+catalogue, so a later `b7-9-janus-ai` edit cannot break the Pythia harness (and
+vice-versa : b7-9's harness should assert the Forbidden catalogue, not the
+Dispatch Table rows).
+
+**Recommendation for the maintainer** : land `b7-pythia` and `b7-9-janus-ai` in
+either order, but NOT concurrently on the same base without rebasing the second.
+If concurrency is required, the disjoint-section design makes the conflict
+trivially resolvable.
+
+## Standards Applied
+
+- **`global/rag-patterns.md`** (B.7.3) — consumed verbatim ; Pythia's Embeddings
+  & Retrieval + pgvector HNSW Tuning + Re-ranking checklists operationalise it.
+- **`global/llm-gateway.md`** (B.7.3) — consumed verbatim ; Prompt Audit &
+  Fallback checklist operationalises it (IX.6 + XI.5 + XI.6).
+- **`global/mcp-servers.md`** (B.7.3) — consumed verbatim ; MCP Server Hardening
+  checklist operationalises it.
+- **`global/compliance-tiers.md`** (I.2) + **`global/forbidden-components-rules.md`**
+  (I.3) — REFERENCED for the tier-aware posture (K2-RULE-001) ; not restated, not
+  edited.
+- **`.claude/agents/observability-specialist.md`** (Panoptes) — structural
+  precedent for an advisory specialist with checklists + deliverables and NO
+  scanner.
+- **`.claude/agents/demeter.md`** (K.3) — structural precedent for the persona
+  layout (Persona / Purpose / Checklists / Output / Rule Catalogue / Integration
+  / Anti-Hallucination / Audit cross-references) + the `<MODULE>-RULE-NNN`
+  convention.
+- **`global/forge-self-ci.md`** (G.1) — `b7-pythia.test.sh` registers in
+  `forge-ci.yml` `harnesses=(...)` per the existing convention.
+
+## Constitutional Compliance Gate
+
+- **Article I (TDD)** : ✅ enforced via `b7-pythia.test.sh` RED → GREEN ;
+  tasks.md Phase 1 writes all L1+L2 stubs FAIL.
+- **Article II (BDD)** : ✅ 3 Gherkin scenarios in specs.md cover dispatch +
+  fallback gate + ef_search clarification.
+- **Article III (Specs Before Code)** : ✅ specs.md + design.md precede any
+  implementation ; spec-only change.
+- **Article III.4** : ✅ Q-001 (BLOCKING name collision) + Q-002 + Q-003 captured ;
+  Q-002/Q-003 answered via ADR-K2-002/003 ; **Q-001 requires maintainer
+  ratification and BLOCKS `implemented`** — never guessed.
+- **Article IV (Delta-Based Changes)** : ✅ ADDED Requirements predominate ; the
+  only MODIFIED entries are the Janus Dispatch Table + Step 3 note + Quality
+  Gates bullet (ADR-K2-004, surgical) and the additive `index.yml` triggers
+  (ADR-K2-005). Disjoint from sibling `b7-9-janus-ai` (collision § above).
+- **Article V (Audit Trail)** : ✅ FR-K2-PYT-* tags + `K2-RULE-NNN` IDs +
+  structured report shape.
+- **Article VI (Flutter)** : N/A (no Flutter ; Pythia advises Hera's Qwik UI by
+  reference but writes none).
+- **Article VII (Rust)** : N/A (Pythia advises Vulcan's RAG/LLM/MCP backend ;
+  writes no Rust).
+- **Article VIII (Infra)** : ✅ trivially — Pythia ships no executable, no
+  service, no daemon (ADR-K2-003).
+- **Article IX.6 (AI Feature Observability)** : ✅ Pythia ENFORCES prompt-audit
+  span coverage (FR-K2-PYT-026 / K2-RULE-005) at design/review time ; emits no
+  OTel itself (review-time agent).
+- **Article X (Code Quality)** : ✅ NFR-K2-PYT-002 (no TS / no executable) ; the
+  Markdown persona + bash harness pass shellcheck per existing CI gates.
+- **Article XI (AI-First Design)** :
+  - **XI.1 (Agent-Native)** : ✅ Pythia is a first-class agent persona (name
+    pending ADR-K2-001 ratification).
+  - **XI.3 (Schema-Driven)** : ✅ Pythia's RAG Readiness Report is structured ;
+    it consumes schema-driven RAG/MCP patterns.
+  - **XI.5 (Mandatory Fallback)** : ✅ K2-RULE-006 is the Blocking gate enforcing
+    a tested non-AI fallback — the single most important check Pythia owns.
+  - **XI.6 (Privacy / Data Minimisation)** : ✅ Embeddings + Prompt Audit
+    checklists assert PII minimisation before chunks reach a provider.
+- **Article XII (Governance)** : ✅ Pythia ENFORCES the AI-First + EU-sovereignty
+  posture ; authors no new standard (consumes `b7-standards`) ; amends no
+  constitutional article.
+
+**No constitutional violation detected. One BLOCKING open question (Q-001 name
+collision) requires maintainer ratification before `/forge:implement`. Design
+proceeds to `/forge:plan`.**
+
+## Open Questions remaining post-design
+
+- Q-001 (name collision) → **recorded in ADR-K2-001 with recommended Option B
+  (rename K.2 agent to Delphi, keep Product-Analyst-Pythia)** ; **NOT
+  auto-resolved** — requires maintainer ratification (touches a shipped persona's
+  identity + the roadmap's stated name). Remains `Status: open` and BLOCKING
+  until ratified.
+- Q-002 (K2-RULE seed size) → **answered by ADR-K2-002** (6 seed rules,
+  incremental, mirroring ADR-K3-005).
+- Q-003 (advisory vs scanner) → **answered by ADR-K2-003** (advisory only, no
+  scanner ; justified by the plan §9 K.2 verbs + non-determinism of tuning).
+
+`open-questions.md` will flip Q-002 + Q-003 to `Status: answered` during
+`/forge:plan` ; **Q-001 stays `open` (BLOCKING)** pending maintainer ratification.

--- a/.forge/changes/b7-pythia/open-questions.md
+++ b/.forge/changes/b7-pythia/open-questions.md
@@ -102,7 +102,7 @@ This question no longer blocks the flip to `implemented`.
 
 ## Q-002: K2-RULE namespace — pre-allocate or grow incrementally?
 
-- **Status**: open
+- **Status**: answered
 - **Raised in**: proposal.md § Solution K.2.a ; specs.md FR-K2-PYT-006 /
   120-cluster
 - **Raised on**: 2026-06-22
@@ -135,13 +135,21 @@ mirroring ADR-K3-005. Per ADR-J8-004 inheritance, IDs are never reused.
 
 ### Resolution
 
-_(pending — to be resolved by ADR-K2-002 in design.md.)_
+**Resolved 2026-06-22 by ADR-K2-002 (design.md).** Chosen: **Option B —
+incremental growth, 6 seed rules**, mirroring `k3-demeter` ADR-K3-005. The seed
+catalogue (`.claude/agents/sibyl.md` § Recommendation Catalogue) is
+`K2-RULE-001..006`: one per checklist area plus the XI.5 fallback gate
+(`K2-RULE-006`, the only `Blocking`-severity rule). Severity vocabulary is
+`Advisory` < `Concern` < `Blocking` (advisory agent — softer than the J8/K3
+policy-refusal ladders). Per ADR-J8-004 inheritance, IDs are never reused; future
+K.2 extensions append `K2-RULE-007..`. Asserted by `b7-pythia.test.sh`
+`_test_b7p_007_rule_catalogue` + `_test_b7p_008_fallback_blocking`.
 
 ---
 
 ## Q-003: Advisory agent vs scanner — does Pythia ship a scanner script?
 
-- **Status**: open
+- **Status**: answered
 - **Raised in**: proposal.md § Solution + § Scope Out ; specs.md (overall shape)
 - **Raised on**: 2026-06-22
 - **Raised by**: @bfontaine
@@ -185,4 +193,16 @@ integrity across a fresh checkout instead.
 
 ### Resolution
 
-_(pending — to be resolved by ADR-K2-003 in design.md.)_
+**Resolved 2026-06-22 by ADR-K2-003 (design.md).** Chosen: **Option B — advisory
+agent, NO scanner.** Sibyl ships only `.claude/agents/sibyl.md` (persona
+checklists + `RAG Readiness Report` template + `K2-RULE-*` catalogue) in the
+`observability-specialist.md` (Panoptes) mould — nothing executable. NO
+`bin/forge-pythia*.sh` / `bin/forge-sibyl*.sh`, NO `.forge/data/*.yml`, NO
+exit-code contract, NO new standard. Rationale: the plan §9 K.2 verbs are
+advisory; HNSW/embeddings tuning is workload-specific and non-deterministic (a
+generic scanner cannot synthesise the adopter's labelled eval set — guessing a
+number would violate Article III.4). The principal justified divergence from the
+`k3-demeter` precedent. Guarded by `b7-pythia.test.sh` `_test_b7p_018_no_scanner`
+(no scanner / data file) + `_test_b7p_013_no_new_standard` (no new standard); the
+single L2 fixture `_test_b7p_l2_anchor_integrity` asserts persona-anchor integrity
+across a fresh checkout instead of a scanner-exit-code run.

--- a/.forge/changes/b7-pythia/open-questions.md
+++ b/.forge/changes/b7-pythia/open-questions.md
@@ -7,7 +7,7 @@ Q-NNN sequential per change, zero-padded to 3 digits, never reused.
 
 ## Q-001: Pythia name collision — K.2 AI/RAG agent vs existing Product Analyst
 
-- **Status**: open (BLOCKING — must resolve before status flips to `implemented`)
+- **Status**: answered
 - **Raised in**: proposal.md § "Naming collision" ; specs.md FR-K2-PYT-001
   (persona name + file path)
 - **Raised on**: 2026-06-22
@@ -78,9 +78,25 @@ suite is name-resolution-agnostic until the ADR locks it.
 
 ### Resolution
 
-_(pending — to be filled by ADR-K2-001 in design.md after maintainer
-ratification. Until then this question BLOCKS the flip to `implemented` per
-Article III.4.)_
+**Resolved 2026-06-22 by @bfontaine (maintainer ratification).** Chosen:
+**Option B — keep "Pythia" for the Product Analyst, name the new K.2 AI/RAG
+specialist agent `Sibyl`.** The maintainer selected **Sibyl** (a Greek
+prophetess/seer — thematically consistent with the oracle motif) over the
+design's recommended "Delphi"; both options keep the shipped
+Product-Analyst-Pythia untouched (zero churn to the 4 existing references).
+
+Binding for `/forge:implement`:
+- `<pythia-name>` placeholder throughout proposal/specs/design/tasks resolves to
+  **Sibyl**.
+- Persona file: `.claude/agents/sibyl.md`; header `# Agent: AI/RAG Specialist (Sibyl)`.
+- Brick name stays `b7-pythia` (it names the brick / the roadmap row, not the
+  persona).
+- The existing `.claude/agents/product-analyst.md` (Pythia) and its 4 references
+  (`forge-master.md` ×2, `onboard.md`, `propose.md`) are **not** modified.
+- ADR-K2-001 in design.md to be updated to record `Sibyl` as the ratified name
+  (superseding its "Delphi" recommendation).
+
+This question no longer blocks the flip to `implemented`.
 
 ---
 

--- a/.forge/changes/b7-pythia/open-questions.md
+++ b/.forge/changes/b7-pythia/open-questions.md
@@ -1,0 +1,172 @@
+# Open Questions — b7-pythia
+
+<!--
+Tracking file per Article III.4 mechanisation.
+Q-NNN sequential per change, zero-padded to 3 digits, never reused.
+-->
+
+## Q-001: Pythia name collision — K.2 AI/RAG agent vs existing Product Analyst
+
+- **Status**: open (BLOCKING — must resolve before status flips to `implemented`)
+- **Raised in**: proposal.md § "Naming collision" ; specs.md FR-K2-PYT-001
+  (persona name + file path)
+- **Raised on**: 2026-06-22
+- **Raised by**: @bfontaine (via b7-pythia planning)
+
+### Question
+
+`docs/new-archetypes-plan.md` §9 line 2665 + §6.2 line 2585 mandate the K.2
+AI/RAG specialist agent be named **Pythia**. But the name is **already taken**:
+`.claude/agents/product-analyst.md` declares `# Agent: Product Analyst (Pythia)`
+— the Delphic-oracle persona used for product analysis / PRFAQ / Working
+Backwards, invoked at `/forge:explore` and `/forge:propose`.
+
+Bindings of "Pythia" → Product Analyst that exist on disk today:
+
+- `.claude/agents/product-analyst.md` (lines 1, 4 — the persona itself).
+- `.claude/agents/forge-master.md` (line 39 dispatch row, line 143 roster).
+- `.claude/commands/forge/onboard.md` (line 54).
+- `.claude/commands/forge/propose.md` (line 31).
+
+Name-based dispatch (`SendMessage to: "Pythia"`, the CLAUDE.md trigger table
+keyed by persona name, the Janus Dispatch Table) cannot disambiguate two agents
+sharing a name. This is a genuine requirements conflict the roadmap author did
+not anticipate (the K.2 "Pythia" was chosen in `ARCHITECTURE-TARGET §9.2`
+apparently without noticing the Product Analyst already owns the name).
+
+Three resolution options:
+
+- **Option A — Keep "Pythia" for K.2 (AI/RAG), rename the Product Analyst.**
+  The roadmap explicitly names the AI/RAG agent "Pythia"; the Product-Analyst
+  "Pythia" is an internal naming choice with no roadmap mandate. Rename the
+  Product Analyst to a non-colliding oracle/strategy name (candidates:
+  **Cassandra**, **Sibyl**, **Tiresias** — all Greek seers/oracles, none used
+  in the current roster). Cost: edit 1 persona + 4 referencing files (mechanical,
+  in `.claude/**` which CLAUDE.md permits as direct writes).
+- **Option B — Keep "Pythia" for the Product Analyst, rename the K.2 agent.**
+  The Product Analyst shipped first; renaming it churns existing references.
+  Pick a new name for the AI/RAG specialist (candidates: **Delphi** — the RAG
+  oracle's seat; **Mnemosyne** — memory/retrieval; **Sophia** — wisdom/knowledge
+  retrieval). The roadmap's "Pythia (AI/RAG)" becomes a documentary alias; the
+  brick name `b7-pythia` stays (it names the brick, not the persona).
+- **Option C — Defer K.2 naming to the maintainer entirely**; ship the persona
+  with a placeholder name and a `[NEEDS CLARIFICATION]` in the file until the
+  maintainer decides. (Weakest — leaves an unnamed agent on disk.)
+
+### Recommendation (for design / maintainer ratification)
+
+Lean **Option B — rename the K.2 AI/RAG agent, keep Product-Analyst-Pythia.**
+Rationale: (1) the Product Analyst is *already shipped* and woven into 4 files +
+two slash commands — renaming a shipped, referenced persona is higher churn and
+higher regression risk than naming a brand-new one; (2) the AI/RAG agent does
+not exist yet, so naming it freshly is zero-churn; (3) the roadmap's "Pythia"
+for K.2 is a label, not a contract — the brick name `b7-pythia` is preserved as
+the documentary link to the roadmap row regardless of the persona's final name.
+
+Recommended new name for the K.2 AI/RAG specialist: **Delphi** (the oracle's
+seat — the place retrieval happens; thematically apt for a
+retrieval-augmented-generation specialist). The brick stays `b7-pythia`; the
+persona file becomes `.claude/agents/delphi.md` and the persona is
+`# Agent: AI/RAG Specialist (Delphi)`.
+
+**This is a maintainer decision** — it touches an already-shipped persona's
+identity and the roadmap's stated name. Article III.4 forbids guessing. Design
+encodes the recommendation as a *parameterised* default (ADR-K2-001) but the
+spec FRs reference the persona via `<pythia-name>` placeholder until ratified.
+The harness asserts the *file* + *anchors*, not the literal name, so the test
+suite is name-resolution-agnostic until the ADR locks it.
+
+### Resolution
+
+_(pending — to be filled by ADR-K2-001 in design.md after maintainer
+ratification. Until then this question BLOCKS the flip to `implemented` per
+Article III.4.)_
+
+---
+
+## Q-002: K2-RULE namespace — pre-allocate or grow incrementally?
+
+- **Status**: open
+- **Raised in**: proposal.md § Solution K.2.a ; specs.md FR-K2-PYT-006 /
+  120-cluster
+- **Raised on**: 2026-06-22
+- **Raised by**: @bfontaine
+
+### Question
+
+`j8-janus-rules` ADR-J8-004 set the `<MODULE>-RULE-NNN` rule-ID format;
+`k3-demeter` inherited it as `K3-RULE-NNN` and chose (ADR-K3-005) **incremental
+growth** (5 seed rules, not pre-allocated). K.2 inherits the format as
+`K2-RULE-NNN`. Two strategies:
+
+- **Option A — pre-allocate** ~10 `K2-RULE-001..010` covering all four
+  responsibility areas now, even if only some carry detailed remediation.
+- **Option B — grow incrementally** — seed the catalogue with the rules the
+  checklists actually need (one or two per responsibility area), append later.
+
+Note: Pythia's rules are **advisory recommendations**, not policy refusals
+(unlike J8-RULE which exits 3 at scaffold time, and unlike K3-RULE which scales
+to BLOCKED). So the rule semantics are softer — `K2-RULE-NNN` flags a *tuning
+recommendation* or a *fallback gate*, severity `Advisory` / `Concern` /
+`Blocking` (Blocking reserved for the XI.5 fallback gate).
+
+### Recommendation
+
+Lean **Option B — incremental**, consistent with the K3-RULE ADR-K3-005
+decision. Seed catalogue of ~6 rules: one per checklist area plus the XI.5
+fallback gate (the only Blocking-severity rule). Resolvable at design via an ADR
+mirroring ADR-K3-005. Per ADR-J8-004 inheritance, IDs are never reused.
+
+### Resolution
+
+_(pending — to be resolved by ADR-K2-002 in design.md.)_
+
+---
+
+## Q-003: Advisory agent vs scanner — does Pythia ship a scanner script?
+
+- **Status**: open
+- **Raised in**: proposal.md § Solution + § Scope Out ; specs.md (overall shape)
+- **Raised on**: 2026-06-22
+- **Raised by**: @bfontaine
+
+### Question
+
+The `k3-demeter` precedent (the brick's stated "patron") ships a **deterministic
+scanner** (`bin/forge-demeter-scan.sh` + Python engine + `.forge/data/
+cloud-act-publishers.yml` deny-list + JSON-report exit-code contract). Should
+`b7-pythia` mirror that scanner machinery, or is Pythia a pure
+advisory/checklist agent (like Panoptes the observability specialist)?
+
+The plan §9 K.2 row scopes Pythia to: *"Embeddings, pgvector tuning (HNSW
+`ef_search`), MCP servers, prompt audit"* — all **tuning / audit / advisory**
+verbs. There is no deny-list to scan, no deterministic jurisdiction
+classification, no reproducible byte-stable report mandated. Tuning `ef_search`
+against a labelled eval set is inherently workload-specific and judgement-based
+— it cannot be reduced to a deterministic grep the way Demeter's CLOUD Act
+deny-list can.
+
+- **Option A — scanner** (full k3-demeter mirror): `bin/forge-pythia-scan.sh`
+  + data file + exit codes. Cost: large surface for a check that is inherently
+  non-deterministic (HNSW tuning depends on the adopter's eval set, which the
+  scanner cannot synthesise).
+- **Option B — advisory agent** (Panoptes mirror): persona checklists + RAG
+  Readiness Report + `K2-RULE-*` recommendation catalogue, NO scanner script,
+  NO data file, NO exit-code contract. Pythia advises at design/review time;
+  the adopter (and the layer orchestrators Vulcan/Hera) act on the advice.
+
+### Recommendation
+
+Lean **Option B — advisory agent, no scanner.** Rationale: (1) the plan verbs
+are advisory; (2) HNSW/embeddings tuning is workload-specific and not
+deterministically scannable; (3) the prompt-audit + fallback checks are
+design/review-time gates Janus already dispatches, not a standalone CLI; (4) a
+scanner that cannot run the adopter's eval set would produce false confidence.
+This is the principal *justified divergence* from the k3-demeter precedent and
+will be recorded as **ADR-K2-003** in design. The harness therefore has **no L2
+scanner-exit-code fixture**; its single L2 fixture asserts persona-anchor
+integrity across a fresh checkout instead.
+
+### Resolution
+
+_(pending — to be resolved by ADR-K2-003 in design.md.)_

--- a/.forge/changes/b7-pythia/proposal.md
+++ b/.forge/changes/b7-pythia/proposal.md
@@ -1,0 +1,298 @@
+# Proposal: b7-pythia
+
+<!-- Created: 2026-06-22 -->
+<!-- Schema: default -->
+<!-- Audit: K.2 (docs/new-archetypes-plan.md §9 line 2665 + §6.2 B.7.4 line 2585 — Pythia AI/RAG specialist agent) -->
+<!-- Audit: B.7.4 (docs/new-archetypes-plan.md §6.2 — Pythia agent for ai-native-rag) -->
+<!-- Precedent: .forge/changes/k3-demeter/ (K.3 Demeter — specialist persona + Janus delta + standard + harness + CLAUDE.md row) -->
+
+## Problem
+
+`docs/new-archetypes-plan.md` mandates a new Forge specialist agent for the
+`ai-native-rag` archetype:
+
+- §9 line 2665 (K-modules table): **K.2 — Pythia (AI/RAG)** — *"Embeddings,
+  pgvector tuning (HNSW `ef_search`), MCP servers, prompt audit"* — archetype
+  `ai-native-rag`, effort `M`.
+- §6.2 line 2585 (B.7.4): *"Nouvel agent **Pythia** (K.2) : pilote embeddings
+  pipeline, tune pgvector (HNSW `ef_search`), MCP servers, prompt audit."*
+- §0.12 brick table line 2022: brick **#4 `b7-pythia` — agent K.2 (patron
+  `k3-demeter`) — ⏳ pending**.
+
+The `ai-native-rag` archetype now has a scaffolder backbone (`b7-2-scaffolder`,
+archived 2026-06-21 — 56 templates: RAG pipeline, in-repo LLM gateway proxy, MCP
+servers, Qwik UI) and three pattern standards (`b7-standards`, archived
+2026-06-13 — `global/{rag-patterns,llm-gateway,mcp-servers}.md`). What it does
+**not** have is a **specialist agent** to drive the AI-specific tuning and audit
+work those templates leave to the adopter: choosing chunk sizes, tuning pgvector
+HNSW `ef_search` against a labelled eval set, sizing the context window, wiring
+the prompt-audit span, hardening MCP tools to least-privilege, and gating the
+mandatory non-AI fallback (Article XI.5).
+
+Today none of this exists as an agent:
+
+- No `.claude/agents/<pythia>.md` persona for the AI/RAG specialist is on disk.
+  The roadmap references the agent by name (§9 + §6.2) but no agent file backs
+  the prose.
+- The three `b7-standards` (`rag-patterns.md`, `llm-gateway.md`,
+  `mcp-servers.md`) are **pattern documents** — they describe the patterns but
+  name no agent that *owns* them. Compare: Demeter owns
+  `data-stewardship-rules.md`; Panoptes owns observability; no agent owns the
+  RAG/LLM/MCP standards.
+- Janus (`cross-layer-orchestrator.md`) has no dispatch path for an AI/RAG
+  review of a `≥ 2`-layer `ai-native-rag` change. Aegis (security) and Demeter
+  (data-stewardship) run at Step 9; nothing runs an AI-specific pass.
+- The repo `CLAUDE.md` agent-delegation table has no row routing AI/RAG tuning
+  work to a specialist.
+
+### Naming collision (BLOCKING — see Q-001)
+
+**The name "Pythia" is already taken in the Forge agent roster.**
+`.claude/agents/product-analyst.md` declares `# Agent: Product Analyst
+(Pythia)` — the Greek oracle of Delphi, used for the product-analysis /
+PRFAQ / Working-Backwards persona invoked during `/forge:explore` and
+`/forge:propose`. The repo `CLAUDE.md` does NOT list Product-Analyst-Pythia
+(it lists Oracle for AI features), but `forge-master.md` (lines 39, 143),
+`product-analyst.md`, `commands/forge/onboard.md` (line 54), and
+`commands/forge/propose.md` (line 31) all bind "Pythia" to the Product
+Analyst.
+
+Two distinct agents cannot share a name in a roster where dispatch is
+name-based (`SendMessage to: "Pythia"` would be ambiguous; the CLAUDE.md
+trigger table is keyed by persona name). This is a genuine requirements
+ambiguity that the roadmap did not anticipate (the roadmap author picked
+"Pythia" for K.2 in `ARCHITECTURE-TARGET §9.2` apparently unaware the name was
+already consumed by the Product Analyst). Per Article III.4 this MUST NOT be
+silently resolved — it is logged as **Q-001** in `open-questions.md` and is the
+single blocking open question of this change.
+
+This change closes the agent gap **at the spec layer only**. The persona file,
+the Janus delta, the standards-index touch, the CLAUDE.md row, and the test
+harness are reserved for the follow-up `/forge:implement b7-pythia` invocation.
+
+## Solution
+
+A single coordinated specialist-agent change, mirroring the `k3-demeter`
+precedent layout but **without** a scanner script: Pythia (K.2) is an
+**advisory / tuning** specialist (like Panoptes the observability specialist),
+not a deterministic-scanner agent (like Demeter). The plan §9 K.2 row scopes
+Pythia to *tuning* + *audit*, not to a reproducible deny-list scan. No
+`bin/forge-*-scan.sh`, no `.forge/data/*.yml` deny-list, no JSON-report exit-code
+contract.
+
+### K.2.a — Pythia persona (`.claude/agents/<name>.md`)
+
+A new agent file authored in the existing Forge specialist style (compare
+`observability-specialist.md` / Panoptes, `security-auditor.md` / Aegis,
+`demeter.md` / Demeter). The persona name is **parameterised pending Q-001**
+(recommended default: keep the roadmap name **Pythia** for the K.2 AI/RAG agent
+and **rename the existing Product-Analyst persona** to a non-colliding oracle
+name — see Q-001 resolution recommendation). The file declares:
+
+- **Persona** — name (pending Q-001), role (AI/RAG specialist for
+  `ai-native-rag`), style (eval-driven, evidence-first, fallback-mandatory).
+- **Purpose** — embeddings pipeline tuning, pgvector HNSW tuning, MCP server
+  hardening, prompt-audit wiring; cites K.2 + B.7.4 + the three b7-standards it
+  consumes.
+- **Checklists** — one H3 per responsibility area, mirroring the Aegis/Demeter
+  greppable `[ ]`-item style: **Embeddings & Retrieval**, **pgvector HNSW
+  Tuning**, **MCP Server Hardening**, **Prompt Audit & Fallback**.
+- **Output: RAG Readiness Report** — a structured advisory report (status
+  `READY` / `TUNING-NEEDED` / `BLOCKED`) mirroring the Demeter/Aegis report
+  shape (Summary table + findings + cleared items), but advisory not
+  policy-refusal.
+- **Recommendation catalogue** — `K2-RULE-NNN` namespace (per the `<MODULE>-RULE-NNN`
+  format ADR-J8-004 established and K3-RULE-* inherited), seed catalogue
+  covering the tuning/audit checks.
+- **Integration** — how Janus dispatches Pythia for `ai-native-rag` cross-layer
+  changes; relationship to Oracle (AI-First brainstorm — Oracle defines the
+  capability/fallback at proposal time, Pythia tunes the realised pipeline at
+  design/review time); relationship to Demeter (Demeter owns dependency
+  jurisdiction + DPA; Pythia owns AI-pipeline tuning — disjoint); relationship
+  to Vulcan/Hera (Pythia advises, the layer orchestrators implement).
+- **Anti-hallucination protocol** — `[NEEDS CLARIFICATION:]` emission when a
+  tuning target is unspecified (no labelled eval set, undeclared embedding
+  model, missing tier) consistent with Article III.4.
+
+### K.2.b — Standards-index ownership touch (NO new standard)
+
+Unlike K.3 (which authored a brand-new `data-stewardship-rules.md`), Pythia does
+**NOT** author a new standard — the three pattern standards it owns already
+exist (`b7-standards`, archived 2026-06-13). The K.2.b deliverable is the
+minimal touch to make Pythia discoverable through the standards-injection
+mechanism:
+
+- Extend the `triggers:` lists of the existing `global/{rag-patterns,
+  llm-gateway,mcp-servers}` entries in `.forge/standards/index.yml` with a
+  `pythia` keyword (and `ef-search`, `embeddings-tuning` as relevant) so the
+  agent is reachable via trigger. This is an **additive edit** to existing
+  entries, NOT a new index entry. Locked at design (ADR).
+
+### K.2.c — Janus + CLAUDE.md dispatch integration
+
+- `.claude/agents/cross-layer-orchestrator.md` (Janus) gains a one-line
+  **Dispatch Table** row routing AI/RAG-specialist work to Pythia, plus a
+  surgical integration into the relevant workflow pass. **Collision note**:
+  this file is co-edited by sibling brick `b7-9-janus-ai` (J.8.c — runtime AI
+  refusal rules). The deltas MUST be disjoint (see `design.md` collision
+  section): Pythia touches the **Dispatch Table** + a **design/tuning** pass;
+  `b7-9-janus-ai` touches the **Forbidden archetypes & combinations** J8-RULE
+  catalogue (scaffold-time refusal). They do not overlap by section.
+- The repo `CLAUDE.md` agent-delegation table gains one new row for the AI/RAG
+  specialist. **Collision note**: `b7-9-janus-ai` may also touch `CLAUDE.md`
+  (Janus compatibility note). Keep the Pythia delta a single table row in the
+  delegation table; flag the file overlap in design.
+
+## Scope In
+
+- New persona file `.claude/agents/<pythia-name>.md` (≈ 200–280 LOC, same
+  density as `observability-specialist.md` / `demeter.md`). Exact filename and
+  persona name locked at design after Q-001 resolves.
+- New `K2-RULE-NNN` recommendation catalogue (namespace allocation per the
+  ADR-J8-004 `<MODULE>-RULE-NNN` extension protocol; disjoint from J8-RULE-*,
+  K3-RULE-*).
+- Additive `triggers:` edits to the three existing `global/{rag-patterns,
+  llm-gateway,mcp-servers}` entries in `.forge/standards/index.yml`.
+- One-line Janus Dispatch-Table row + a surgical workflow-pass integration in
+  `.claude/agents/cross-layer-orchestrator.md`.
+- One-line repo `CLAUDE.md` agent-table row.
+- Test harness `.forge/scripts/tests/b7-pythia.test.sh` (grep-based L1 + 1 L2
+  fixture, mirrors `k3.test.sh` layout), registered in `.github/workflows/forge-ci.yml`.
+- Doc updates: `CHANGELOG.md` `## [Unreleased]` entry; agent-catalogue doc entry
+  if one exists (located at design).
+
+## Scope Out (Explicit Exclusions)
+
+- **NOT** a scanner script. Pythia is advisory/tuning (plan §9 K.2 — "tune
+  pgvector", "MCP servers", "prompt audit"), not a deterministic deny-list
+  scanner. No `bin/forge-pythia-*.sh`, no `.forge/data/*.yml`, no JSON-report
+  exit-code contract. (This is the principal divergence from the `k3-demeter`
+  precedent and is justified by ADR at design.)
+- **NOT** a new standard file. The three RAG/LLM/MCP pattern standards already
+  exist (`b7-standards`). Pythia consumes them; it does not re-author them.
+- **NOT** the runtime Janus AI refusal rules (J.8.c — Vertex/Bedrock refusal,
+  T3 ⇒ Mistral-EU/vLLM). Those are sibling brick `b7-9-janus-ai` (#5). Pythia
+  REFERENCES the tier-aware posture (`compliance-tiers.md` / `llm-gateway.md`)
+  but ships no J8-RULE.
+- **NOT** the AI-Act / DORA compliance artefacts (`b7-5-ai-act`, #6 / Themis
+  K.5). Pythia's prompt-audit checklist references IX.6 transparency but ships
+  no regulatory artefact.
+- **NOT** the scaffolder templates or the candidate→stable promotion
+  (`b7-2-scaffolder` archived; `b7-6-harness` for promotion). Pythia does not
+  edit `templates/ai-native-rag/`, the schema, or the wrapper.
+- **NOT** the Qwik streaming transport (`b7-10-streaming`) or the example
+  project (`b7-7-example`).
+- **NOT** a rename of the existing Product-Analyst-Pythia in *this* change
+  unless Q-001 resolves that way at design. The persona name is parameterised;
+  the change name `b7-pythia` is stable regardless (it names the brick, not the
+  persona).
+- **NOT** the `.claude/agents/<name>.md` file itself in this PR. **This change
+  is spec-only.** The persona file is the GREEN state of `/forge:implement
+  b7-pythia`, not of `/forge:specify` / `/forge:design` / `/forge:plan`.
+
+## Impact
+
+- **Users affected**:
+  - Adopters of the `ai-native-rag` archetype gain a named specialist that
+    drives embeddings/retrieval tuning, pgvector HNSW tuning, MCP hardening, and
+    prompt-audit/fallback wiring — the work the `b7-2-scaffolder` templates left
+    as `#[cfg(test)]`-scaffolded TODO.
+  - Janus gains an AI/RAG dispatch path for `ai-native-rag` cross-layer changes.
+  - No change for adopters of other archetypes (Pythia is `ai-native-rag`-scoped).
+- **Technical impact**: ≈ 1 new file (persona) + 1 new harness + ≈ 4 modified
+  (Janus dispatch + workflow pass, standards index triggers, repo CLAUDE.md row,
+  CHANGELOG, forge-ci.yml matrix). No scanner, no data file, no new standard.
+  **Effort `M`** per `new-archetypes-plan` §1.4 / §9 row K.2.
+- **Dependencies**:
+  - `b7-standards` (archived 2026-06-13) — ships the three pattern standards
+    Pythia owns/consumes.
+  - `b7-2-scaffolder` (archived 2026-06-21) — ships the templates whose tuning
+    Pythia drives (RAG pipeline / LLM gateway / MCP servers).
+  - `k3-demeter` (archived 2026-05-12) — precedent for the persona + Janus delta
+    + harness + CLAUDE.md row layout; source of the `<MODULE>-RULE-NNN`
+    namespace convention Pythia's `K2-RULE-*` inherits.
+  - `j8-janus-rules` — ADR-J8-004 rule-ID format.
+  - No new external dependency. No code, no pins.
+- **Risk level**: **Low → Medium**. The persona file is pure documentation. The
+  only meaningful risk is the **Q-001 name collision** — shipping a second
+  "Pythia" would break name-based dispatch. Mitigated by treating Q-001 as a
+  blocking gate (status cannot flip to `implemented` until resolved) and by
+  parameterising the persona name through specs/design.
+- **Shared-file collision risk** (sibling bricks): `cross-layer-orchestrator.md`
+  and repo `CLAUDE.md` are co-edited by `b7-9-janus-ai`. Mitigated by disjoint
+  sectioning (Pythia → Dispatch Table + design pass; b7-9 → J8-RULE forbidden
+  catalogue). Detailed in `design.md` § "Shared-file collision with sibling
+  bricks".
+
+## Constitution Compliance
+
+### Article I — TDD
+
+RED → GREEN → REFACTOR enforced. `tasks.md` Phase 1 writes
+`b7-pythia.test.sh` with all L1 + L2 stubs returning `_not_implemented` (full
+RED witness) before any persona content is authored. Phase 2+ implements one
+cluster at a time, flipping tests GREEN.
+
+### Article II — BDD
+
+The user-facing flow (Janus dispatches Pythia for an `ai-native-rag`
+cross-layer change and receives a RAG Readiness Report) gets a Given/When/Then
+scenario in `specs.md`. Pythia is an advisory agent, so the scenarios assert
+report shape + dispatch wiring, not a CLI exit code.
+
+### Article III — Specs Before Code
+
+Confirmed: `/forge:specify` writes `specs.md` with the `FR-K2-PYT-*` namespace
+before any implementation. This change is spec-only.
+
+### Article III.4 — `[NEEDS CLARIFICATION:]` Discipline
+
+The **name collision (Q-001)** is the canonical Article III.4 case: a genuine
+requirements ambiguity the roadmap did not resolve. It is logged in
+`open-questions.md` and BLOCKS the flip to `implemented`. Q-002 (RULE namespace
+seed size) and Q-003 (advisory-vs-scanner shape) are also tracked; both are
+resolvable at design.
+
+### Article IX.6 — AI Feature Observability
+
+Pythia ENFORCES IX.6 at design/review time: its Prompt Audit checklist asserts
+the gateway emits the prompt-audit span (model / tenant / tier / token counts /
+latency / fallback flag) per `llm-gateway.md`. Pythia does not itself emit OTel
+(it is a design/review-time agent, not a runtime component).
+
+### Article XI — AI-First Design
+
+- **XI.1 (Agent-Native)** — Pythia is a first-class agent persona file.
+- **XI.3 (Schema-Driven)** — Pythia's output is a structured advisory report;
+  it consumes the schema-driven RAG/MCP patterns, recommends no opaque
+  AI-generated artefact.
+- **XI.5 (Mandatory Fallback)** — Pythia's Prompt Audit & Fallback checklist
+  asserts every LLM-backed feature has a tested non-AI fallback (RAG returns
+  ranked source documents). This is the single most important gate Pythia owns.
+- **XI.6 (Privacy / Data Minimisation)** — Pythia's Embeddings checklist asserts
+  PII minimisation before chunks reach an embedding/LLM provider.
+
+### Article XII — Governance
+
+Pythia ENFORCES the AI-First posture (Article XI) + the EU sovereignty posture
+encoded in `compliance-tiers.md` + `llm-gateway.md`. It does **not amend** any
+constitutional article. It authors no new standard (consumes existing
+`b7-standards`).
+
+## Open Questions
+
+Inline `[NEEDS CLARIFICATION:]` markers in this `proposal.md`: the name
+collision is surfaced narratively above and formalised in `open-questions.md`.
+Three open questions raised at this phase, all tracked in `open-questions.md`:
+
+- **Q-001 (BLOCKING)** — Pythia name collision: the K.2 AI/RAG agent and the
+  existing Product Analyst both want the name "Pythia". Which agent keeps it,
+  and what is the other named? Resolution recommendation drafted; final call is
+  the maintainer's (it touches an already-shipped persona + 4 referencing
+  files).
+- **Q-002** — `K2-RULE-NNN` seed catalogue size: pre-allocate vs grow
+  incrementally (mirror the K3-RULE Q-003 decision — incremental). Resolvable at
+  design.
+- **Q-003** — Advisory-report shape vs Demeter-style scanner: confirm Pythia
+  ships NO scanner (advisory only, like Panoptes), diverging from the
+  scanner-heavy `k3-demeter` precedent. Resolvable at design via ADR.

--- a/.forge/changes/b7-pythia/specs.md
+++ b/.forge/changes/b7-pythia/specs.md
@@ -1,0 +1,471 @@
+# Specifications: b7-pythia
+
+<!-- Status: specified -->
+<!-- Schema: default -->
+
+**Namespace** : `FR-K2-PYT-*` / `NFR-K2-PYT-*` / `ADR-K2-*`. **Constitution** :
+v2.0.0. No amendment required (K.2 introduces a new advisory specialist agent ;
+existing articles unchanged ; it ENFORCES Articles IX.6 + XI, does not amend
+them).
+
+> **Persona-name placeholder** : throughout this spec the persona is referenced
+> as `<pythia-name>` (file) / `<Pythia-Name>` (display). The literal name is
+> BLOCKED on Q-001 (name collision with the existing Product-Analyst-Pythia) and
+> is locked by ADR-K2-001 at design after maintainer ratification. The harness
+> asserts file + anchors, not the literal name, so the FRs are
+> name-resolution-agnostic until the ADR locks the value.
+
+## Source Documents
+
+| Field             | Value                                                                                                                                                                  |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Audit base**    | `K.2` (`docs/new-archetypes-plan.md` §9 line 2665 — K-modules table) + `B.7.4` (`docs/new-archetypes-plan.md` §6.2 line 2585 — Pythia agent for ai-native-rag)        |
+| **Precedent**     | `.forge/changes/k3-demeter/` (K.3 Demeter — persona + Janus delta + standard + harness + CLAUDE.md row layout) ; `.claude/agents/observability-specialist.md` (Panoptes — advisory-specialist shape, NO scanner) |
+| **Plan ref**      | `docs/new-archetypes-plan.md` §0.12 brick table line 2022 (brick #4) ; §6.2 line 2585 (B.7.4) ; §9 line 2665 (K.2) ; `docs/ARCHITECTURE-TARGET.md` §9.2 (agent introduction) |
+| **Standards owned/consumed** | `global/rag-patterns.md` (b7-standards) ; `global/llm-gateway.md` (b7-standards) ; `global/mcp-servers.md` (b7-standards) ; references `global/compliance-tiers.md` (I.2) + `global/forbidden-components-rules.md` (I.3) for the tier-aware posture |
+| **Pattern reuse** | `j8-janus-rules` ADR-J8-004 (`<MODULE>-RULE-NNN` rule-ID format) ; `k3-demeter` ADR-K3-005 (incremental rule growth) ; `k3-demeter` ADR-K3-007 (Janus delta-based modification per Article IV.1) |
+| **Schema ref**    | `.forge/schemas/ai-native-rag/1.0.0.yaml` (b7-1-schema — `embeddings-pipeline` + `prompt-audit` phases ; `ai_specifics.fallback_mandatory` ; the pipeline Pythia tunes) |
+| **Scaffold ref**  | `b7-2-scaffolder` (archived 2026-06-21 — RAG pipeline / in-repo LLM gateway proxy / MCP server templates Pythia advises on) |
+| **Collision**     | `.claude/agents/product-analyst.md` (existing `Pythia` — Q-001) ; `b7-9-janus-ai` sibling brick co-edits `cross-layer-orchestrator.md` + `CLAUDE.md` (disjoint sections — design § collision) |
+| **Constitution**  | Article IX.6 (AI feature observability — prompt audit) ; Article XI.1/XI.3/XI.5/XI.6 (AI-First — agent-native, schema-driven, mandatory fallback, PII minimisation) |
+
+---
+
+## ADDED Requirements
+
+### Functional Requirements
+
+#### Cluster 1 — Pythia persona file (FR-K2-PYT-001 → 008)
+
+##### FR-K2-PYT-001 — Persona file location
+
+A new persona file MUST exist under `.claude/agents/<pythia-name>.md` at the path
+locked by ADR-K2-001 (design phase, after Q-001 resolves). The file follows the
+`.claude/agents/<name>.md` flat-layout convention used by all top-level Forge
+specialists (e.g. `observability-specialist.md`, `security-auditor.md`,
+`demeter.md`). The filename and the persona's display name are BLOCKED on Q-001.
+
+##### FR-K2-PYT-002 — Persona section
+
+The file MUST start with an H1 `# Agent: AI/RAG Specialist (<Pythia-Name>)` and a
+`## Persona` H2 declaring:
+- **Name** : `<Pythia-Name>` (locked by ADR-K2-001).
+- **Role** : AI/RAG specialist for the `ai-native-rag` archetype — drives
+  embeddings/retrieval tuning, pgvector HNSW tuning, MCP server hardening, and
+  prompt-audit/fallback wiring.
+- **Style** : Eval-driven, evidence-first, fallback-mandatory. Mirrors the
+  Aegis/Demeter stylistic pattern (every recommendation carries a severity,
+  specific evidence, and an actionable tuning step). Gates changes on a labelled
+  eval set, not vibes (per `rag-patterns.md` § Evaluation).
+
+##### FR-K2-PYT-003 — Purpose section
+
+A `## Purpose` H2 MUST describe Pythia's four responsibilities and explicitly
+cite the source audit items (K.2 + B.7.4) and the three b7-standards Pythia
+consumes (`rag-patterns.md`, `llm-gateway.md`, `mcp-servers.md`). It MUST state
+that Pythia is `ai-native-rag`-scoped (not invoked on other archetypes).
+
+##### FR-K2-PYT-004 — Checklists section
+
+A `## Checklists` H2 MUST host at least four H3 sub-sections, each in the
+Aegis/Demeter greppable `[ ]`-item style with `Verify:` / `Check:` / `Exception:`
+annotations (≥ 5 `[ ]` items per sub-section):
+- **Embeddings & Retrieval** (chunking strategy, embedding model tier-gating,
+  hybrid vector + BM25 + RRF, distance-op matching) — consumes `rag-patterns.md`.
+- **pgvector HNSW Tuning** (`ef_search` recall/latency trade-off,
+  `iterative_scan` for filtered queries, opclass↔distance-op match, eval-gated
+  tuning) — consumes `rag-patterns.md` § pgvector HNSW tuning.
+- **MCP Server Hardening** (least-privilege tools, input validation, no arbitrary
+  execution, OAuth 2.1 → Zitadel/Envoy) — consumes `mcp-servers.md`.
+- **Prompt Audit & Fallback** (prompt-audit span per IX.6, tenant budgets, kill
+  switch, mandatory non-AI fallback XI.5, PII minimisation XI.6) — consumes
+  `llm-gateway.md`.
+
+##### FR-K2-PYT-005 — Output report format
+
+An `## Output: RAG Readiness Report` H2 MUST declare the report shape, mirroring
+the Demeter/Aegis report template but **advisory** (not policy-refusal):
+- A `Summary` table with severity counts (`Blocking` / `Concern` / `Advisory` /
+  `Cleared`).
+- A `Findings` section with per-finding entries citing `[SEVERITY] <K2-RULE-NNN>:
+  <title>`, `Category`, `Location`, `Evidence`, `Recommendation`, `Verification`.
+- A `Cleared Items` section.
+- An overall status line: `BLOCKED` / `TUNING-NEEDED` / `READY`
+  (`BLOCKED` only when the XI.5 mandatory-fallback gate fails — the single
+  Blocking-severity case ; `TUNING-NEEDED` on any Concern ; `READY` otherwise).
+
+##### FR-K2-PYT-006 — Recommendation catalogue section
+
+A `## Recommendation Catalogue` H2 MUST enumerate the seed `K2-RULE-*` rules
+(≥ 5 rules, see Cluster 5). Each rule MUST cite: (a) trigger condition, (b)
+severity (`Advisory` / `Concern` / `Blocking`), (c) evidence pattern, (d) tuning
+recommendation, (e) cross-link to the relevant b7-standard or constitutional
+article.
+
+##### FR-K2-PYT-007 — Integration section
+
+A `## Integration` H2 MUST describe:
+- How Janus dispatches Pythia for `ai-native-rag` cross-layer changes (cross-link
+  to `cross-layer-orchestrator.md` — exact pass locked by ADR-K2-004).
+- The relationship to **Oracle** (AI-First Brainstorm): Oracle defines the AI
+  capability + the mandatory fallback at proposal/brainstorm time; Pythia tunes
+  the *realised* pipeline at design/review time. Disjoint phases.
+- The relationship to **Demeter** (K.3): Demeter owns dependency-jurisdiction +
+  DPA + tier classification; Pythia owns AI-pipeline tuning + prompt-audit +
+  fallback. Disjoint surfaces (Demeter does NOT tune `ef_search`; Pythia does NOT
+  scan `Cargo.lock` jurisdiction).
+- The relationship to **Vulcan / Hera** (layer orchestrators): Pythia *advises*;
+  Vulcan (Rust backend: RAG pipeline, LLM gateway, MCP) and Hera (Qwik frontend)
+  *implement*. Pythia writes no application code.
+
+##### FR-K2-PYT-008 — Anti-hallucination protocol
+
+A `## Anti-Hallucination Protocol` H2 MUST state the Article III.4 contract:
+when a tuning target is unspecified (no labelled eval set to tune `ef_search`
+against, an undeclared embedding model, an undeclared compliance tier that gates
+the provider), Pythia MUST emit `[NEEDS CLARIFICATION: <specific question>]` and
+STOP — never guess a tuning value. It MUST NOT fabricate `ef_search` numbers,
+chunk sizes, or recall@k targets absent an eval set.
+
+---
+
+#### Cluster 2 — Audit anchors + citations (FR-K2-PYT-010 → 011)
+
+##### FR-K2-PYT-010 — Audit comment
+
+The persona file MUST carry a top-of-file `<!-- Audit: K.2 (b7-pythia) -->`
+HTML comment per the Forge audit-trail convention. A second
+`<!-- Audit: B.7.4 (b7-pythia) -->` comment MUST be added (B.7.4 is the §6.2
+plan item that mandates the agent).
+
+##### FR-K2-PYT-011 — Source citations
+
+The persona footer MUST cite the upstream sources that justify Pythia's
+existence, with section + line refs (same convention as `demeter.md` footer):
+- `docs/new-archetypes-plan.md` §9 line 2665 (K.2 row)
+- `docs/new-archetypes-plan.md` §6.2 line 2585 (B.7.4)
+- `docs/new-archetypes-plan.md` §0.12 brick table line 2022 (brick #4)
+- `docs/ARCHITECTURE-TARGET.md` §9.2 (agent introduction)
+- the three b7-standards owned/consumed.
+
+---
+
+#### Cluster 3 — Tuning-domain coverage (FR-K2-PYT-020 → 027)
+
+These FRs pin *what* the checklists must cover, sourced verbatim from the
+b7-standards Pythia consumes. Pythia MUST NOT redefine or contradict the
+standards — it operationalises them as review-time checks.
+
+##### FR-K2-PYT-020 — Chunking & embeddings coverage
+
+The Embeddings & Retrieval checklist MUST cover: semantic-unit chunking with
+token-budgeted overlap (≈10–20%), provenance metadata storage for citation, and
+embedding normalisation matched to the distance op — per `rag-patterns.md` §
+Chunking & embeddings.
+
+##### FR-K2-PYT-021 — Embedding-model tier-gating
+
+The checklist MUST assert the embedding-model choice is tier-gated: T3
+(EU-strict) MUST use a self-hosted model or an EU-sovereign provider (Mistral on
+Scaleway); OpenAI-direct embeddings are forbidden at T3 — per `rag-patterns.md`
+§ EU sovereignty + `llm-gateway.md` § Tier-aware refusal. Pythia REFERENCES the
+tier matrix (`compliance-tiers.md`) ; it does NOT restate it.
+
+##### FR-K2-PYT-022 — Hybrid retrieval coverage
+
+The checklist MUST cover hybrid search (pgvector similarity + Postgres full-text
+BM25-like `ts_rank`, fused via Reciprocal Rank Fusion) and matching the distance
+operator (`<->` L2 / `<=>` cosine / `<#>` inner product) to the embedding space
+— per `rag-patterns.md` § Retrieval.
+
+##### FR-K2-PYT-023 — pgvector HNSW `ef_search` tuning
+
+The pgvector HNSW Tuning checklist MUST cover `SET hnsw.ef_search = N` (recall
+vs latency), tuned per workload **against a labelled eval set** (recall@k /
+nDCG), and `hnsw.iterative_scan` (`strict_order` / `relaxed_order` / `off`) for
+filtered queries — per `rag-patterns.md` § pgvector HNSW tuning. This is the K.2
+headline responsibility (plan §9 names "`ef_search`" explicitly).
+
+##### FR-K2-PYT-024 — Re-ranking coverage
+
+The checklist MUST cover coarse→exact two-stage re-ranking (binary-quantized
+Hamming wide pass → exact distance re-order, optional cross-encoder) — per
+`rag-patterns.md` § Re-ranking.
+
+##### FR-K2-PYT-025 — MCP least-privilege + auth coverage
+
+The MCP Server Hardening checklist MUST cover: one-capability-per-tool least
+privilege, derived-`JsonSchema` + explicit-bounds input validation, no arbitrary
+execution / no shell-out / path allow-listing, and OAuth 2.1 + PKCE → Zitadel
+issuer with Envoy JWT edge validation — per `mcp-servers.md` § Security + §
+Authentication.
+
+##### FR-K2-PYT-026 — Prompt-audit span coverage (IX.6)
+
+The Prompt Audit & Fallback checklist MUST assert the gateway emits a
+prompt-audit record per LLM call (model / tenant / tier / prompt+completion token
+counts / latency / provider / fallback-invocation flag) — per `llm-gateway.md` §
+Prompt audit & observability + Article IX.6. PII MUST be redacted before logging
+(XI.6).
+
+##### FR-K2-PYT-027 — Mandatory-fallback gate coverage (XI.5)
+
+The checklist MUST assert every LLM-backed feature has a defined, **tested**
+non-AI fallback (e.g. RAG returns ranked source documents when generation is
+unavailable), and a tenant-scoped budget + kill switch that degrade to the
+fallback rather than hard-fail — per `llm-gateway.md` § Budgets/kill switch/
+fallback + Article XI.5. This is the **only Blocking-severity** check Pythia
+owns (a feature with no tested fallback is "not considered complete" per XI.5).
+
+---
+
+#### Cluster 4 — Standards-index + Janus + CLAUDE.md integration (FR-K2-PYT-080 → 086)
+
+##### FR-K2-PYT-080 — Standards-index trigger additivity (NO new standard)
+
+`.forge/standards/index.yml` MUST be edited **additively** to make Pythia
+discoverable: the existing `global/rag-patterns`, `global/llm-gateway`, and
+`global/mcp-servers` entries (the B.7.3 block, lines ~439-455) gain a `pythia`
+trigger keyword (and `ef-search` / `embeddings-tuning` where apt). NO new index
+entry is created — Pythia authors no new standard (it owns the three existing
+ones). Exact keyword set locked by ADR-K2-005.
+
+##### FR-K2-PYT-081 — No new standard file
+
+This change MUST NOT create any new `.forge/standards/global/*.md` file. The
+RAG/LLM/MCP pattern standards already exist (`b7-standards`). Asserted as a guard
+so reviewers can confirm Pythia's "ownership" is by-reference, not by
+re-authoring (diverges from K.3 which DID author `data-stewardship-rules.md`).
+
+##### FR-K2-PYT-082 — Janus Dispatch-Table row
+
+`.claude/agents/cross-layer-orchestrator.md` MUST gain a single new row in its
+**Dispatch Table** (the H2 table at lines ~23-32 today), routing AI/RAG
+specialist work to Pythia. The row MUST be placed **after** the Demeter row and
+**before** the closing `---` of the table (the same insertion site convention
+K.3 used for the Demeter row). Exact row text locked by ADR-K2-004.
+
+##### FR-K2-PYT-083 — Janus workflow-pass integration
+
+`.claude/agents/cross-layer-orchestrator.md` MUST integrate Pythia into the
+relevant workflow pass via a **delta-based modification** (Article IV.1, mirrors
+ADR-K3-007). The integration site is locked by ADR-K2-004 — candidate sites:
+the **Step 3 design dispatch** (Pythia advises the per-layer RAG design for
+`ai-native-rag` projects) or a dedicated note in the **Quality Gates** H2. The
+delta MUST be surgical and MUST NOT touch the Step 9 Security &
+Data-Stewardship narrative (that is Aegis + Demeter territory) nor the Forbidden
+archetypes / J8-RULE catalogue (that is `b7-9-janus-ai` territory — see
+collision note FR-K2-PYT-086).
+
+##### FR-K2-PYT-084 — CLAUDE.md trigger registration
+
+The repo-level `CLAUDE.md` agent-delegation table (lines ~61-71) MUST gain a new
+row routing AI/RAG tuning work to the K.2 specialist. The row text is locked by
+ADR-K2-001 (depends on the persona name). Placement: within the existing
+delegation table, adjacent to the `AI features | Oracle` row (Pythia and Oracle
+are the two AI-domain agents). The CLAUDE.md `## About Forge` / agent-table
+already lists Oracle for AI features; this row adds the AI/RAG *tuning*
+specialist as distinct from Oracle's *brainstorm* role.
+
+##### FR-K2-PYT-085 — Scaffolding dispatch-table NOT edited
+
+`.forge/scaffolding/dispatch-table.yml` MUST NOT be edited. Pythia is a
+Janus-time / review-time advisory agent, not a scaffold-time init dispatcher (same
+posture as Demeter per FR-K3-DEM-085). Asserted as a guard.
+
+##### FR-K2-PYT-086 — No RULE-namespace collision
+
+The `K2-RULE-*` namespace MUST NOT collide with `J8-RULE-*` (Janus forbidden
+catalogue), `K3-RULE-*` (Demeter), or any other `<MODULE>-RULE-*` namespace. The
+`<MODULE>-RULE-NNN` format (ADR-J8-004) makes collision syntactically impossible;
+the spec asserts the invariant so reviewers can grep for it. **Sibling-brick
+collision**: `b7-9-janus-ai` (J.8.c) will add `J8-RULE-*` AI refusal rules to the
+Janus *Forbidden archetypes* catalogue — Pythia's `K2-RULE-*` are advisory
+recommendations in the *persona file*, a disjoint surface. The two never share a
+section nor a namespace.
+
+---
+
+#### Cluster 5 — Seed K2-RULE catalogue (FR-K2-PYT-120 → 125)
+
+The seed K.2 recommendation catalogue per ADR-K2-002 (design — incremental, ~6
+rules). Severity vocabulary: `Advisory` (tuning suggestion), `Concern`
+(should-fix before production), `Blocking` (XI.5 fallback gate only).
+
+##### FR-K2-PYT-120 — K2-RULE-001 — Embedding model not tier-gated
+
+**Trigger**: the declared embedding provider is OpenAI-direct (or
+Vertex/Bedrock) at compliance tier T3. **Severity**: `Concern` (cross-links to
+the I.3 `forbidden-components` linter which is the *blocking* enforcement; Pythia
+flags it at design time so it is caught before the linter fails CI).
+**Recommendation**: switch to a self-hosted model or Mistral-on-Scaleway per
+`rag-patterns.md` § EU sovereignty.
+
+##### FR-K2-PYT-121 — K2-RULE-002 — HNSW `ef_search` untuned / no eval set
+
+**Trigger**: pgvector HNSW index in use but `ef_search` left at default AND no
+labelled eval set is present to tune against. **Severity**: `Advisory` (no eval
+set) → emits `[NEEDS CLARIFICATION:]` rather than a fabricated number.
+**Recommendation**: build a labelled retrieval eval set; tune `ef_search` for
+recall@k vs latency per `rag-patterns.md` § pgvector HNSW tuning.
+
+##### FR-K2-PYT-122 — K2-RULE-003 — Pure-vector retrieval (no hybrid)
+
+**Trigger**: retrieval uses pgvector similarity only, no Postgres full-text /
+BM1-like fusion. **Severity**: `Advisory`. **Recommendation**: add hybrid search
++ RRF for keyword-heavy / out-of-distribution recall per `rag-patterns.md` §
+Retrieval.
+
+##### FR-K2-PYT-123 — K2-RULE-004 — MCP tool over-privileged
+
+**Trigger**: an MCP tool exposes more than one capability, shells out, evals, or
+uses a path argument verbatim (no allow-list). **Severity**: `Concern`.
+**Recommendation**: split into one-capability tools; validate inputs against the
+derived `JsonSchema`; resolve paths against an allow-list per `mcp-servers.md` §
+Security.
+
+##### FR-K2-PYT-124 — K2-RULE-005 — Prompt-audit span missing (IX.6)
+
+**Trigger**: an LLM gateway call path emits no prompt-audit record (model /
+tenant / tier / token counts / latency / fallback flag). **Severity**: `Concern`.
+**Recommendation**: emit the prompt-audit span per `llm-gateway.md` § Prompt
+audit + Article IX.6; redact PII (XI.6).
+
+##### FR-K2-PYT-125 — K2-RULE-006 — Mandatory fallback missing/untested (XI.5)
+
+**Trigger**: an LLM-backed feature has no defined non-AI fallback, OR a fallback
+exists but no test exercises it with the AI mocked to fail. **Severity**:
+`Blocking` (the only Blocking rule — XI.5 says a feature with no tested fallback
+"is not considered complete"). **Recommendation**: define + test the non-AI
+fallback (RAG returns ranked source documents); wire the kill switch + budget to
+degrade to it, not hard-fail.
+
+---
+
+### Non-Functional Requirements
+
+#### NFR-K2-PYT-001 — Backward compatibility
+
+This change is purely additive. Adopters not invoking Pythia (no `ai-native-rag`
+project, no Janus AI-pass dispatch) MUST observe ZERO behavioural change. No
+existing persona's behaviour changes — EXCEPT the Q-001 rename, which is a
+maintainer-ratified identity edit tracked separately and gated by ADR-K2-001.
+
+#### NFR-K2-PYT-002 — No application code, no scanner, no pins
+
+Pythia is a `.claude/agents/` Markdown persona only. This change MUST NOT create
+any `bin/forge-*.sh`, any `.forge/data/*.yml`, any `cli/src/**.ts`, any version
+pin, any template, or any Rust/Dart/TS source. Asserted as a guard against
+task-creep toward the scanner shape (which ADR-K2-003 explicitly rejects).
+
+#### NFR-K2-PYT-003 — Article V audit trail
+
+Every task tagged `[Story: FR-K2-PYT-XXX]` (Article V.1, enforced by
+`f4-linter-extension`). Every Pythia finding carries a `K2-RULE-NNN` ID in the
+report's structured shape.
+
+#### NFR-K2-PYT-004 — Standards consumed, not amended
+
+Pythia consumes `rag-patterns.md` / `llm-gateway.md` / `mcp-servers.md` verbatim
+and MUST NOT edit, contradict, or re-author them. The only standards-layer touch
+is the additive `triggers:` keyword in `index.yml` (FR-K2-PYT-080). No standard's
+*content* changes.
+
+#### NFR-K2-PYT-005 — No regression in sibling harnesses
+
+`verify.sh`, `constitution-linter.sh`, `validate-standards-yaml.sh`, `j7`, `j8`,
+`k3`, `b7-1`, `b7-2a`, `b7-3`, `b7-2` MUST remain GREEN. The `index.yml` edit is
+additive (extends `triggers:` arrays) so `validate-standards-yaml.sh` /
+`j7.test.sh` do not regress.
+
+#### NFR-K2-PYT-006 — Shared-file edit disjointness
+
+The edits to `cross-layer-orchestrator.md` and `CLAUDE.md` MUST be confined to
+sections disjoint from `b7-9-janus-ai`'s edits (Pythia → Dispatch Table +
+design/quality pass + delegation row ; b7-9 → Forbidden archetypes / J8-RULE
+catalogue + Janus-compat note). Whichever brick lands second rebases its
+surgical delta onto the first. Detailed in `design.md` § collision.
+
+#### NFR-K2-PYT-007 — Name-resolution agnostic harness
+
+The test harness MUST assert the persona *file presence* + *H2/H3 anchors* +
+*K2-RULE anchors*, NOT the literal persona name, so the suite passes regardless
+of how Q-001 resolves (the harness resolves the agent path from a single
+variable locked at implementation once ADR-K2-001 fixes the name).
+
+---
+
+## BDD Acceptance Criteria
+
+### Scenario 1 — Janus dispatches Pythia for an ai-native-rag cross-layer change
+
+```gherkin
+Given a project whose root .forge.yaml declares schema: ai-native-rag
+And a change touching backend/ (RAG pipeline) and frontend/ (Qwik UI) — 2 layers
+When Janus processes the cross-layer change
+Then Janus dispatches to <Pythia-Name> for the AI/RAG specialist pass
+And <Pythia-Name> returns a RAG Readiness Report with an overall status line
+And the report's status is BLOCKED if and only if the XI.5 mandatory-fallback gate (K2-RULE-006) fails
+```
+
+### Scenario 2 — Mandatory-fallback gate blocks an untested feature (XI.5)
+
+```gherkin
+Given an ai-native-rag feature calls the LLM gateway for generation
+And no test exercises a non-AI fallback with the AI mocked to fail
+When <Pythia-Name> runs its Prompt Audit & Fallback checklist
+Then the report contains 1 finding with rule_id "K2-RULE-006" and severity "Blocking"
+And the overall status is "BLOCKED"
+And the recommendation cites "define + test the non-AI fallback per Article XI.5"
+```
+
+### Scenario 3 — Untuned ef_search with no eval set emits NEEDS CLARIFICATION (III.4)
+
+```gherkin
+Given an ai-native-rag project uses a pgvector HNSW index with default ef_search
+And no labelled retrieval eval set is present in the project
+When <Pythia-Name> runs its pgvector HNSW Tuning checklist
+Then it emits "[NEEDS CLARIFICATION: no labelled eval set — cannot tune ef_search without recall@k targets]"
+And it does NOT fabricate an ef_search value
+And the finding is recorded under rule_id "K2-RULE-002" severity "Advisory"
+```
+
+---
+
+## Anti-Hallucination Pass
+
+For each FR:
+
+- **Testable** : every FR is asserted by at least one test in
+  `b7-pythia.test.sh` (mapping captured in `tasks.md` `[Story: FR-K2-PYT-XXX]`
+  tags during `/forge:plan`).
+- **Unambiguous** : 3 open questions flagged — Q-001 (name collision, BLOCKING),
+  Q-002 (RULE seed size), Q-003 (advisory-vs-scanner). Q-002 + Q-003 resolvable
+  at design via ADR-K2-002 / ADR-K2-003. **Q-001 is a genuine blocking ambiguity
+  requiring maintainer ratification** — the spec is parameterised on
+  `<pythia-name>` precisely so the FRs remain unambiguous about *structure* while
+  the *name* is deferred (Article III.4 — never guess).
+- **Constitution-compliant** : Articles I (TDD), II (BDD), III + III.4 (specs
+  first + ambiguity protocol), IV.1 (Janus delta-based modification), V (audit
+  trail), IX.6 (prompt audit — Pythia enforces), XI.1/3/5/6 (AI-First — Pythia
+  enforces), XII (governance — enforces, does not amend ; authors no new
+  standard).
+
+---
+
+## Open Questions
+
+Inline `[NEEDS CLARIFICATION:]` markers in this `specs.md` : none (the name
+ambiguity is parameterised via `<pythia-name>`, not left as an inline marker, so
+the FRs read cleanly). Three open questions Q-001 (BLOCKING) + Q-002 + Q-003
+tracked in `open-questions.md`, slated for resolution during `/forge:design` via
+ADR-K2-001..005 (Q-001 additionally requires maintainer ratification).
+
+## Counts
+
+- **FR-K2-PYT-*** : 31 (8 persona 001-008, 2 audit/citations 010-011, 8 tuning
+  coverage 020-027, 7 integration 080-086, 6 seed rules 120-125)
+- **NFR-K2-PYT-*** : 7 (001-007)
+- **BDD Scenarios** : 3
+- **Open Questions** : 3 (Q-001 BLOCKING + Q-002 + Q-003, all status `open`)
+- **ADRs (planned, design phase)** : 5 (ADR-K2-001..005)

--- a/.forge/changes/b7-pythia/tasks.md
+++ b/.forge/changes/b7-pythia/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: b7-pythia
 
-<!-- Status: planned -->
+<!-- Status: implemented -->
 <!-- Schema: default -->
 
 ## Convention
@@ -35,22 +35,22 @@ state captured ; CI registration done. No persona name required yet.
 
 ### T-PHA — harness skeleton
 
-- [ ] **T-PHA-001** : Create `.forge/scripts/tests/b7-pythia.test.sh` with bash
+- [x] **T-PHA-001** : Create `.forge/scripts/tests/b7-pythia.test.sh` with bash
       header (`#!/usr/bin/env bash`, `set -uo pipefail`, source `_helpers.sh`),
       PASS/FAIL counters, `--level 1,2` parsing, `print_summary` close-out.
       Mirror the `k3.test.sh` layout. Resolve `PYTHIA_AGENT` from a single
       variable defaulting to the ADR-K2-001 recommended path
       (`.claude/agents/delphi.md`) overridable by env, so the suite is
       name-agnostic. [Story: FR-K2-PYT-001 / NFR-K2-PYT-007]
-- [ ] **T-PHA-002** : Add **18 L1 test stubs** returning `_not_implemented`
+- [x] **T-PHA-002** : Add **18 L1 test stubs** returning `_not_implemented`
       covering the 18 anchor IDs in `design.md` § "L1 anchor-level" table.
       [Story: FR-K2-PYT-001..086]
-- [ ] **T-PHA-003** [P] : Add **1 L2 fixture stub** (`_test_b7p_l2_anchor_integrity`)
+- [x] **T-PHA-003** [P] : Add **1 L2 fixture stub** (`_test_b7p_l2_anchor_integrity`)
       using `mk_tmpdir_with_trap`. [Story: NFR-K2-PYT-007]
-- [ ] **T-PHA-004** [P] : Register `b7-pythia.test.sh --level 1,2` in
+- [x] **T-PHA-004** [P] : Register `b7-pythia.test.sh --level 1,2` in
       `.github/workflows/forge-ci.yml` `harnesses=(...)` array immediately after
       `"b7-2.test.sh --level 1"`. [Story: FR-K2-PYT (CI) / NFR-K2-PYT-005]
-- [ ] **T-PHA-005** : RED gate confirmed —
+- [x] **T-PHA-005** : RED gate confirmed —
       `bash .forge/scripts/tests/b7-pythia.test.sh --level 1,2 > /tmp/b7p-red.log 2>&1` ;
       exit 1 ; `Failed: 19 / Passed: 0`. [Story: Article I]
 
@@ -61,11 +61,11 @@ state captured ; CI registration done. No persona name required yet.
 
 ## Phase 0.5 — GATE : Q-001 maintainer ratification (BLOCKING)
 
-- [ ] **T-Q01-001** : Surface ADR-K2-001 + `open-questions.md` Q-001 to the
+- [x] **T-Q01-001** : Surface ADR-K2-001 + `open-questions.md` Q-001 to the
       maintainer. Obtain a ratified persona name + file path (recommended
       default : Option B — name the K.2 agent **Delphi**, keep
       Product-Analyst-Pythia). [Story: FR-K2-PYT-001 / Article III.4]
-- [ ] **T-Q01-002** : Once ratified, edit `open-questions.md` to flip Q-001 to
+- [x] **T-Q01-002** : Once ratified, edit `open-questions.md` to flip Q-001 to
       `Status: answered` with a `### Resolution` block citing the maintainer
       decision + ADR-K2-001. Lock `PYTHIA_AGENT` in the harness to the ratified
       path (single-line edit, T-PHA-001 variable). [Story: Article III.4]
@@ -87,10 +87,10 @@ tests flip GREEN (`_test_b7p_001..011`).
 
 ### T-PER — persona skeleton
 
-- [ ] **T-PER-001** : RED witness — convert `_test_b7p_001_persona_exists` +
+- [x] **T-PER-001** : RED witness — convert `_test_b7p_001_persona_exists` +
       `_test_b7p_002_audit_comment` + `_test_b7p_003_persona_h2`.
       [Story: FR-K2-PYT-001..003 / 010]
-- [ ] **T-PER-002** : Create `.claude/agents/<pythia-name>.md` (ratified path)
+- [x] **T-PER-002** : Create `.claude/agents/<pythia-name>.md` (ratified path)
       with :
       - `<!-- Audit: K.2 (b7-pythia) -->` + `<!-- Audit: B.7.4 (b7-pythia) -->`
         HTML comments at top.
@@ -99,14 +99,14 @@ tests flip GREEN (`_test_b7p_001..011`).
       - H2 `## Purpose` per FR-K2-PYT-003 (cite K.2 + B.7.4 + the 3 b7-standards ;
         state `ai-native-rag`-scoped).
       [Story: FR-K2-PYT-001..003 / 010 / ADR-K2-001]
-- [ ] **T-PER-003** : Run harness ; expect 3 persona-skeleton L1 tests GREEN.
+- [x] **T-PER-003** : Run harness ; expect 3 persona-skeleton L1 tests GREEN.
       [Story: FR-K2-PYT-001..003]
 
 ### T-CHK — checklists section
 
-- [ ] **T-CHK-001** : RED witness — convert `_test_b7p_004_checklists_h2` +
+- [x] **T-CHK-001** : RED witness — convert `_test_b7p_004_checklists_h2` +
       `_test_b7p_005_checklists_items`. [Story: FR-K2-PYT-004]
-- [ ] **T-CHK-002** : Add `## Checklists` H2 with 4 H3 sub-sections (≥ 5 `[ ]`
+- [x] **T-CHK-002** : Add `## Checklists` H2 with 4 H3 sub-sections (≥ 5 `[ ]`
       items each, Aegis/Demeter style with Verify/Check/Exception) :
       - **Embeddings & Retrieval** — chunking + tier-gated embedding model +
         hybrid retrieval + distance-op match (FR-K2-PYT-020..022).
@@ -118,55 +118,55 @@ tests flip GREEN (`_test_b7p_001..011`).
       - **Prompt Audit & Fallback** — prompt-audit span IX.6 (FR-K2-PYT-026) +
         budgets/kill-switch + mandatory fallback XI.5 (FR-K2-PYT-027) + PII XI.6.
       Cite the consumed b7-standard in each H3. [Story: FR-K2-PYT-004 / 020..027]
-- [ ] **T-CHK-003** : Run harness ; expect 2 checklist L1 tests GREEN.
+- [x] **T-CHK-003** : Run harness ; expect 2 checklist L1 tests GREEN.
       [Story: FR-K2-PYT-004]
 
 ### T-OUT — RAG Readiness Report shape
 
-- [ ] **T-OUT-001** : RED witness — convert `_test_b7p_006_output_h2`.
+- [x] **T-OUT-001** : RED witness — convert `_test_b7p_006_output_h2`.
       [Story: FR-K2-PYT-005]
-- [ ] **T-OUT-002** : Add `## Output: RAG Readiness Report` H2 (advisory, mirrors
+- [x] **T-OUT-002** : Add `## Output: RAG Readiness Report` H2 (advisory, mirrors
       Demeter report shape) : Summary table (Blocking/Concern/Advisory/Cleared
       counts) + Findings template (`[SEVERITY] <K2-RULE-NNN>:` + Category /
       Location / Evidence / Recommendation / Verification) + Cleared Items +
       overall status line (BLOCKED only on K2-RULE-006 / TUNING-NEEDED on any
       Concern / READY otherwise). [Story: FR-K2-PYT-005]
-- [ ] **T-OUT-003** : Run harness ; expect 1 output-shape L1 test GREEN.
+- [x] **T-OUT-003** : Run harness ; expect 1 output-shape L1 test GREEN.
       [Story: FR-K2-PYT-005]
 
 ### T-CAT — recommendation catalogue (K2-RULE-001..006)
 
-- [ ] **T-CAT-001** : RED witness — convert `_test_b7p_007_rule_catalogue` +
+- [x] **T-CAT-001** : RED witness — convert `_test_b7p_007_rule_catalogue` +
       `_test_b7p_008_fallback_blocking`. [Story: FR-K2-PYT-006 / 120..125]
-- [ ] **T-CAT-002** : Add `## Recommendation Catalogue` H2 with a table
+- [x] **T-CAT-002** : Add `## Recommendation Catalogue` H2 with a table
       enumerating K2-RULE-001..006 per FR-K2-PYT-120..125. Each row : trigger,
       severity (Advisory/Concern/Blocking), evidence pattern, recommendation,
       b7-standard / Article cross-link. K2-RULE-006 MUST be `Blocking` and cite
       XI.5. Document the severity vocabulary + the ADR-J8-004 numbering invariant.
       [Story: FR-K2-PYT-006 / 120..125 / ADR-K2-002]
-- [ ] **T-CAT-003** : Run harness ; expect rule-catalogue + fallback-blocking L1
+- [x] **T-CAT-003** : Run harness ; expect rule-catalogue + fallback-blocking L1
       tests GREEN. [Story: FR-K2-PYT-006 / 125]
 
 ### T-INT — integration + anti-hallucination + standards-consumed + footer
 
-- [ ] **T-INT-001** : RED witness — convert `_test_b7p_009_integration` +
+- [x] **T-INT-001** : RED witness — convert `_test_b7p_009_integration` +
       `_test_b7p_010_anti_halluc` + `_test_b7p_011_standards_consumed`.
       [Story: FR-K2-PYT-007 / 008 / 003]
-- [ ] **T-INT-002** : Add `## Integration` H2 documenting : Janus Step 3 dispatch
+- [x] **T-INT-002** : Add `## Integration` H2 documenting : Janus Step 3 dispatch
       for `ai-native-rag` (cross-link to `cross-layer-orchestrator.md` Step 3 as
       modified by ADR-K2-004) ; relationship to Oracle (brainstorm vs tune) ;
       relationship to Demeter (disjoint surfaces) ; relationship to Vulcan/Hera
       (advise vs implement). Reference all three b7-standards by name (satisfies
       `_test_b7p_011`). [Story: FR-K2-PYT-007 / ADR-K2-004]
-- [ ] **T-INT-003** : Add `## Anti-Hallucination Protocol` H2 — Article III.4
+- [x] **T-INT-003** : Add `## Anti-Hallucination Protocol` H2 — Article III.4
       contract : emit `[NEEDS CLARIFICATION:]` and STOP when a tuning target is
       unspecified (no eval set for `ef_search`, undeclared embedding model,
       undeclared tier) ; never fabricate `ef_search` / chunk-size / recall@k.
       [Story: FR-K2-PYT-008 / 121 / NFR (anti-halluc)]
-- [ ] **T-INT-004** : Add file footer with the audit cross-references per
+- [x] **T-INT-004** : Add file footer with the audit cross-references per
       FR-K2-PYT-011 (new-archetypes-plan §9 / §6.2 / §0.12 + ARCHITECTURE-TARGET
       §9.2 + the 3 b7-standards). [Story: FR-K2-PYT-011]
-- [ ] **T-INT-005** : Run harness ; expect integration + anti-halluc +
+- [x] **T-INT-005** : Run harness ; expect integration + anti-halluc +
       standards-consumed L1 tests GREEN. [Story: FR-K2-PYT-007 / 008 / 003]
 
 **Phase 2 exit gate** : 11 L1 tests GREEN (`_test_b7p_001..011`). `verify.sh`
@@ -182,54 +182,54 @@ this phase, the remaining 7 L1 tests flip GREEN (`_test_b7p_012..018`).
 
 ### T-IDX — standards-index additive triggers (ADR-K2-005)
 
-- [ ] **T-IDX-001** : RED witness — convert `_test_b7p_012_index_triggers` +
+- [x] **T-IDX-001** : RED witness — convert `_test_b7p_012_index_triggers` +
       `_test_b7p_013_no_new_standard`. [Story: FR-K2-PYT-080 / 081]
-- [ ] **T-IDX-002** : Edit `.forge/standards/index.yml` — extend the `triggers:`
+- [x] **T-IDX-002** : Edit `.forge/standards/index.yml` — extend the `triggers:`
       arrays of `global/rag-patterns`, `global/llm-gateway`, `global/mcp-servers`
       (the B.7.3 block) with the ratified persona-name keyword (e.g. `pythia` or
       `delphi`) ; add `ef-search` + `embeddings-tuning` to `rag-patterns`. NO new
       index entry, NO new standard file. [Story: FR-K2-PYT-080 / ADR-K2-005]
-- [ ] **T-IDX-003** : Run harness + `validate-standards-yaml.sh` ; expect index
+- [x] **T-IDX-003** : Run harness + `validate-standards-yaml.sh` ; expect index
       triggers + no-new-standard L1 tests GREEN and J.7 still PASS.
       [Story: FR-K2-PYT-080 / 081 / NFR-K2-PYT-004 / 005]
 
 ### T-JAN — Janus delta edit (ADR-K2-004, Article IV.1)
 
-- [ ] **T-JAN-001** : RED witness — convert `_test_b7p_014_janus_dispatch_row` +
+- [x] **T-JAN-001** : RED witness — convert `_test_b7p_014_janus_dispatch_row` +
       `_test_b7p_015_janus_step3_note`. [Story: FR-K2-PYT-082 / 083 / ADR-K2-004]
-- [ ] **T-JAN-002** : Edit `.claude/agents/cross-layer-orchestrator.md` Dispatch
+- [x] **T-JAN-002** : Edit `.claude/agents/cross-layer-orchestrator.md` Dispatch
       Table — insert the `<Pythia-Name>` AI/RAG row AFTER the Demeter row (line
       32) and BEFORE the closing `---` (line 34) per the verbatim block in
       ADR-K2-004. Do NOT modify any other row ; do NOT touch the Step 9 narrative
       or the Forbidden-archetypes catalogue (b7-9-janus-ai territory).
       [Story: FR-K2-PYT-082 / ADR-K2-004 / NFR-K2-PYT-006]
-- [ ] **T-JAN-003** : Edit `### Step 3 — Parallel Design Dispatch` — append the
+- [x] **T-JAN-003** : Edit `### Step 3 — Parallel Design Dispatch` — append the
       `ai-native-rag` Pythia AI-pipeline design-pass paragraph per ADR-K2-004.
       Add a one-bullet "AI/RAG readiness gate" entry to the **Quality Gates** H2.
       Leave Step 9 (Aegis + Demeter) UNCHANGED. [Story: FR-K2-PYT-083 / ADR-K2-004]
-- [ ] **T-JAN-004** [P] : Edit Janus **Constitution compliance** H2 — add one
+- [x] **T-JAN-004** [P] : Edit Janus **Constitution compliance** H2 — add one
       bullet citing AI-First (Article XI.5 + IX.6) reviewed by `<Pythia-Name>` for
       `ai-native-rag`. [Story: FR-K2-PYT-083 / ADR-K2-004]
-- [ ] **T-JAN-005** : Run harness ; expect 2 Janus L1 tests GREEN ; assert Step 9
+- [x] **T-JAN-005** : Run harness ; expect 2 Janus L1 tests GREEN ; assert Step 9
       Demeter narrative byte-unchanged (k3.test.sh `_test_k3_018` still GREEN).
       [Story: FR-K2-PYT-082..083 / NFR-K2-PYT-005 / 006]
 
 ### T-CLM — CLAUDE.md trigger row
 
-- [ ] **T-CLM-001** : RED witness — convert `_test_b7p_016_claude_md_trigger`.
+- [x] **T-CLM-001** : RED witness — convert `_test_b7p_016_claude_md_trigger`.
       [Story: FR-K2-PYT-084]
-- [ ] **T-CLM-002** : Edit repo `CLAUDE.md` agent-delegation table (lines ~61-71)
+- [x] **T-CLM-002** : Edit repo `CLAUDE.md` agent-delegation table (lines ~61-71)
       — insert a row routing AI/RAG tuning work to `<Pythia-Name>` (AI/RAG
       Specialist), adjacent to the `AI features | Oracle` row. Exact row text per
       the ratified name (ADR-K2-001). [Story: FR-K2-PYT-084]
-- [ ] **T-CLM-003** : Run harness ; expect CLAUDE.md L1 test GREEN.
+- [x] **T-CLM-003** : Run harness ; expect CLAUDE.md L1 test GREEN.
       [Story: FR-K2-PYT-084]
 
 ### T-NSC — namespace + no-scanner guards
 
-- [ ] **T-NSC-001** : RED witness — convert `_test_b7p_017_no_namespace_collision`
+- [x] **T-NSC-001** : RED witness — convert `_test_b7p_017_no_namespace_collision`
       + `_test_b7p_018_no_scanner`. [Story: FR-K2-PYT-086 / NFR-K2-PYT-002]
-- [ ] **T-NSC-002** : Verify (no edit needed if invariants hold) :
+- [x] **T-NSC-002** : Verify (no edit needed if invariants hold) :
       `grep -r "K2-RULE" .claude/agents/cross-layer-orchestrator.md
       .forge/standards/global/janus-orchestration-rules.md
       .claude/agents/demeter.md` returns empty (the J8/K3 surfaces never reference
@@ -237,18 +237,18 @@ this phase, the remaining 7 L1 tests flip GREEN (`_test_b7p_012..018`).
       except as cross-link acknowledgement ; AND no `bin/forge-pythia*.sh` /
       `.forge/data/pythia*.yml` exist. [Story: FR-K2-PYT-086 / NFR-K2-PYT-002 /
       ADR-K2-003]
-- [ ] **T-NSC-003** : Run harness `--level 1,2` ; expect ALL 19 tests (18 L1 + 1
+- [x] **T-NSC-003** : Run harness `--level 1,2` ; expect ALL 19 tests (18 L1 + 1
       L2) GREEN. [Story: FR-K2-PYT-086 / 101 / NFR-K2-PYT-007]
 
 ### T-L2 — L2 fixture
 
-- [ ] **T-L2-001** : RED witness — convert `_test_b7p_l2_anchor_integrity`.
+- [x] **T-L2-001** : RED witness — convert `_test_b7p_l2_anchor_integrity`.
       [Story: NFR-K2-PYT-007]
-- [ ] **T-L2-002** : Implement the L2 fixture — copy `$PYTHIA_AGENT` into a
+- [x] **T-L2-002** : Implement the L2 fixture — copy `$PYTHIA_AGENT` into a
       tmpdir, re-run the L1 anchor greps (H2/H3 + K2-RULE-001..006) against the
       isolated copy ; assert all present (proves the persona is self-contained,
       no scanner needed). [Story: NFR-K2-PYT-007 / ADR-K2-003]
-- [ ] **T-L2-003** : Run harness `--level 1,2` ; expect 19/19 GREEN ≤ 5 s.
+- [x] **T-L2-003** : Run harness `--level 1,2` ; expect 19/19 GREEN ≤ 5 s.
       [Story: NFR-K2-PYT-007]
 
 **Phase 3 exit gate** : `b7-pythia.test.sh --level 1,2` 19/19 GREEN (18 L1 + 1
@@ -261,7 +261,7 @@ PASS. `validate-standards-yaml.sh` / `j7` / `j8` / `k3` GREEN (no regression).
 
 ### T-OQ — open-questions flip
 
-- [ ] **T-OQ-001** : Edit `open-questions.md` to flip Q-002 + Q-003 from
+- [x] **T-OQ-001** : Edit `open-questions.md` to flip Q-002 + Q-003 from
       `Status: open` to `Status: answered` with `### Resolution` blocks citing
       ADR-K2-002 / ADR-K2-003. **Q-001 stays `open` (BLOCKING) until the
       maintainer ratifies ADR-K2-001 (T-Q01-002)** — the archival gate checks
@@ -270,11 +270,11 @@ PASS. `validate-standards-yaml.sh` / `j7` / `j8` / `k3` GREEN (no regression).
 
 ### T-DOC — documentation
 
-- [ ] **T-DOC-001** [P] : Add an agent-catalogue entry for `<Pythia-Name>` (AI/RAG
+- [x] **T-DOC-001** [P] : Add an agent-catalogue entry for `<Pythia-Name>` (AI/RAG
       Specialist) to the agents doc located at impl time (likely a section in
       `docs/` or the `forge-master.md` roster — locked at impl). Summarise
       persona + 4 responsibilities + Janus Step 3 dispatch. [Story: FR-K2-PYT-007]
-- [ ] **T-DOC-002** [P] : Add a `## [Unreleased]` entry in `CHANGELOG.md`
+- [x] **T-DOC-002** [P] : Add a `## [Unreleased]` entry in `CHANGELOG.md`
       covering the K.2 Pythia/`<Pythia-Name>` AI/RAG specialist (persona + Janus
       delta + standards-index triggers + harness). Note the Q-001 rename if
       Option A was chosen. [Story: FR-K2-PYT (docs)]
@@ -290,18 +290,18 @@ PASS. `validate-standards-yaml.sh` / `j7` / `j8` / `k3` GREEN (no regression).
       (audit trail), IX.6 (prompt audit enforced), XI.1/3/5/6 (AI-First
       enforced), XII (governance — no new standard, no amendment). Block if any
       returns VIOLATION. [Story: Article V]
-- [ ] **T-REV-002** : Run full `verify.sh` + all sibling harnesses (`j7` / `j8` /
+- [x] **T-REV-002** : Run full `verify.sh` + all sibling harnesses (`j7` / `j8` /
       `k3` / `b7-1` / `b7-2a` / `b7-3` / `b7-2`) on a clean checkout ; confirm no
       regression (NFR-K2-PYT-005). [Story: NFR-K2-PYT-005]
 - [ ] **T-REV-003** : Verify `bin/forge-questions.sh --change b7-pythia --status
       open` returns ONLY Q-001 (BLOCKING) until maintainer ratification ; empty
       after T-Q01-002. The change MUST NOT archive while Q-001 is open.
       [Story: Article III.4]
-- [ ] **T-REV-004** : Smoke the 3 BDD scenarios from specs.md as a manual reviewer
+- [x] **T-REV-004** : Smoke the 3 BDD scenarios from specs.md as a manual reviewer
       read-through of the persona (dispatch wiring / K2-RULE-006 Blocking gate /
       `ef_search` NEEDS-CLARIFICATION) — no executable to run (advisory agent).
       [Story: Article II]
-- [ ] **T-REV-005** : Confirm the Janus Step 3 note + Dispatch Table row read
+- [x] **T-REV-005** : Confirm the Janus Step 3 note + Dispatch Table row read
       cleanly and the Step 9 Demeter narrative + Forbidden-archetypes catalogue
       are untouched (collision guard vs b7-9-janus-ai). [Story: NFR-K2-PYT-006]
 

--- a/.forge/changes/b7-pythia/tasks.md
+++ b/.forge/changes/b7-pythia/tasks.md
@@ -1,0 +1,363 @@
+# Tasks: b7-pythia
+
+<!-- Status: planned -->
+<!-- Schema: default -->
+
+## Convention
+
+- TDD order is **immutable** : write the test, watch it fail (RED), write the
+  artefact, watch it pass (GREEN), refactor.
+- Audit trail tag `[Story: FR-K2-PYT-XXX]` (Article V.1, enforced by
+  `f4-linter-extension`) on every task.
+- `[P]` marks tasks parallelizable with other `[P]` tasks in the **same phase**.
+- Each phase ends with a **gate task** that runs
+  `bash .forge/scripts/tests/b7-pythia.test.sh` (and `verify.sh` /
+  `constitution-linter.sh` where relevant) and confirms expected counter
+  movement.
+- ADRs from `design.md` (ADR-K2-001..005) are honored verbatim ; deviations
+  require a new ADR.
+- **BLOCKING PRECONDITION** : ADR-K2-001 (persona name, Q-001) MUST be ratified
+  by the maintainer **before Phase 2** (the persona file is authored). Phase 1
+  (RED harness) is name-agnostic and may proceed ; Phase 2+ cannot start until
+  the name is locked. The harness resolves `PYTHIA_AGENT` from one variable
+  (NFR-K2-PYT-007) so Phase 1 does not depend on the name.
+- **DIVERGENCE FROM PRECEDENT** : per ADR-K2-003, this brick ships **NO scanner**
+  (`bin/forge-*.sh`), **NO data file**, **NO new standard**. Tasks that would
+  build those in the `k3-demeter` precedent are intentionally absent. NFR-K2-PYT-002
+  is guarded by an explicit negative test (`_test_b7p_018_no_scanner`).
+
+---
+
+## Phase 1 — Foundation : RED harness (name-agnostic)
+
+Goal : `b7-pythia.test.sh` exists with **18 L1 + 1 L2** stubs all FAIL ; full RED
+state captured ; CI registration done. No persona name required yet.
+
+### T-PHA — harness skeleton
+
+- [ ] **T-PHA-001** : Create `.forge/scripts/tests/b7-pythia.test.sh` with bash
+      header (`#!/usr/bin/env bash`, `set -uo pipefail`, source `_helpers.sh`),
+      PASS/FAIL counters, `--level 1,2` parsing, `print_summary` close-out.
+      Mirror the `k3.test.sh` layout. Resolve `PYTHIA_AGENT` from a single
+      variable defaulting to the ADR-K2-001 recommended path
+      (`.claude/agents/delphi.md`) overridable by env, so the suite is
+      name-agnostic. [Story: FR-K2-PYT-001 / NFR-K2-PYT-007]
+- [ ] **T-PHA-002** : Add **18 L1 test stubs** returning `_not_implemented`
+      covering the 18 anchor IDs in `design.md` § "L1 anchor-level" table.
+      [Story: FR-K2-PYT-001..086]
+- [ ] **T-PHA-003** [P] : Add **1 L2 fixture stub** (`_test_b7p_l2_anchor_integrity`)
+      using `mk_tmpdir_with_trap`. [Story: NFR-K2-PYT-007]
+- [ ] **T-PHA-004** [P] : Register `b7-pythia.test.sh --level 1,2` in
+      `.github/workflows/forge-ci.yml` `harnesses=(...)` array immediately after
+      `"b7-2.test.sh --level 1"`. [Story: FR-K2-PYT (CI) / NFR-K2-PYT-005]
+- [ ] **T-PHA-005** : RED gate confirmed —
+      `bash .forge/scripts/tests/b7-pythia.test.sh --level 1,2 > /tmp/b7p-red.log 2>&1` ;
+      exit 1 ; `Failed: 19 / Passed: 0`. [Story: Article I]
+
+**Phase 1 exit gate** : `b7-pythia.test.sh --level 1,2` exits 1 with `FAIL ≥ 19`,
+`forge-ci.yml` matrix updated, `constitution-linter.sh` OVERALL PASS.
+
+---
+
+## Phase 0.5 — GATE : Q-001 maintainer ratification (BLOCKING)
+
+- [ ] **T-Q01-001** : Surface ADR-K2-001 + `open-questions.md` Q-001 to the
+      maintainer. Obtain a ratified persona name + file path (recommended
+      default : Option B — name the K.2 agent **Delphi**, keep
+      Product-Analyst-Pythia). [Story: FR-K2-PYT-001 / Article III.4]
+- [ ] **T-Q01-002** : Once ratified, edit `open-questions.md` to flip Q-001 to
+      `Status: answered` with a `### Resolution` block citing the maintainer
+      decision + ADR-K2-001. Lock `PYTHIA_AGENT` in the harness to the ratified
+      path (single-line edit, T-PHA-001 variable). [Story: Article III.4]
+
+**Gate** : Phase 2 MUST NOT begin until T-Q01-002 is complete. If the maintainer
+rejects Option B (e.g. picks Option A — rename the Product Analyst), an
+**additional task family T-RENAME-*** is appended here to rename
+`product-analyst.md` + the 4 referencing files (`forge-master.md` ×2,
+`onboard.md`, `propose.md`) and update their dispatch rows — scoped at
+ratification time, not pre-committed.
+
+---
+
+## Phase 2 — K.2.a : Pythia persona file
+
+Goal : `.claude/agents/<pythia-name>.md` ships with all mandatory H2 sections +
+audit comments + 4 checklist H3 + 6 K2-RULE entries. After this phase, 11 L1
+tests flip GREEN (`_test_b7p_001..011`).
+
+### T-PER — persona skeleton
+
+- [ ] **T-PER-001** : RED witness — convert `_test_b7p_001_persona_exists` +
+      `_test_b7p_002_audit_comment` + `_test_b7p_003_persona_h2`.
+      [Story: FR-K2-PYT-001..003 / 010]
+- [ ] **T-PER-002** : Create `.claude/agents/<pythia-name>.md` (ratified path)
+      with :
+      - `<!-- Audit: K.2 (b7-pythia) -->` + `<!-- Audit: B.7.4 (b7-pythia) -->`
+        HTML comments at top.
+      - H1 `# Agent: AI/RAG Specialist (<Pythia-Name>)`.
+      - H2 `## Persona` per FR-K2-PYT-002 (Name / Role / Style — eval-driven).
+      - H2 `## Purpose` per FR-K2-PYT-003 (cite K.2 + B.7.4 + the 3 b7-standards ;
+        state `ai-native-rag`-scoped).
+      [Story: FR-K2-PYT-001..003 / 010 / ADR-K2-001]
+- [ ] **T-PER-003** : Run harness ; expect 3 persona-skeleton L1 tests GREEN.
+      [Story: FR-K2-PYT-001..003]
+
+### T-CHK — checklists section
+
+- [ ] **T-CHK-001** : RED witness — convert `_test_b7p_004_checklists_h2` +
+      `_test_b7p_005_checklists_items`. [Story: FR-K2-PYT-004]
+- [ ] **T-CHK-002** : Add `## Checklists` H2 with 4 H3 sub-sections (≥ 5 `[ ]`
+      items each, Aegis/Demeter style with Verify/Check/Exception) :
+      - **Embeddings & Retrieval** — chunking + tier-gated embedding model +
+        hybrid retrieval + distance-op match (FR-K2-PYT-020..022).
+      - **pgvector HNSW Tuning** — `ef_search` recall/latency eval-gated +
+        `iterative_scan` + opclass match (FR-K2-PYT-023) + re-ranking
+        (FR-K2-PYT-024).
+      - **MCP Server Hardening** — least-privilege + input validation + no-exec +
+        OAuth 2.1→Zitadel (FR-K2-PYT-025).
+      - **Prompt Audit & Fallback** — prompt-audit span IX.6 (FR-K2-PYT-026) +
+        budgets/kill-switch + mandatory fallback XI.5 (FR-K2-PYT-027) + PII XI.6.
+      Cite the consumed b7-standard in each H3. [Story: FR-K2-PYT-004 / 020..027]
+- [ ] **T-CHK-003** : Run harness ; expect 2 checklist L1 tests GREEN.
+      [Story: FR-K2-PYT-004]
+
+### T-OUT — RAG Readiness Report shape
+
+- [ ] **T-OUT-001** : RED witness — convert `_test_b7p_006_output_h2`.
+      [Story: FR-K2-PYT-005]
+- [ ] **T-OUT-002** : Add `## Output: RAG Readiness Report` H2 (advisory, mirrors
+      Demeter report shape) : Summary table (Blocking/Concern/Advisory/Cleared
+      counts) + Findings template (`[SEVERITY] <K2-RULE-NNN>:` + Category /
+      Location / Evidence / Recommendation / Verification) + Cleared Items +
+      overall status line (BLOCKED only on K2-RULE-006 / TUNING-NEEDED on any
+      Concern / READY otherwise). [Story: FR-K2-PYT-005]
+- [ ] **T-OUT-003** : Run harness ; expect 1 output-shape L1 test GREEN.
+      [Story: FR-K2-PYT-005]
+
+### T-CAT — recommendation catalogue (K2-RULE-001..006)
+
+- [ ] **T-CAT-001** : RED witness — convert `_test_b7p_007_rule_catalogue` +
+      `_test_b7p_008_fallback_blocking`. [Story: FR-K2-PYT-006 / 120..125]
+- [ ] **T-CAT-002** : Add `## Recommendation Catalogue` H2 with a table
+      enumerating K2-RULE-001..006 per FR-K2-PYT-120..125. Each row : trigger,
+      severity (Advisory/Concern/Blocking), evidence pattern, recommendation,
+      b7-standard / Article cross-link. K2-RULE-006 MUST be `Blocking` and cite
+      XI.5. Document the severity vocabulary + the ADR-J8-004 numbering invariant.
+      [Story: FR-K2-PYT-006 / 120..125 / ADR-K2-002]
+- [ ] **T-CAT-003** : Run harness ; expect rule-catalogue + fallback-blocking L1
+      tests GREEN. [Story: FR-K2-PYT-006 / 125]
+
+### T-INT — integration + anti-hallucination + standards-consumed + footer
+
+- [ ] **T-INT-001** : RED witness — convert `_test_b7p_009_integration` +
+      `_test_b7p_010_anti_halluc` + `_test_b7p_011_standards_consumed`.
+      [Story: FR-K2-PYT-007 / 008 / 003]
+- [ ] **T-INT-002** : Add `## Integration` H2 documenting : Janus Step 3 dispatch
+      for `ai-native-rag` (cross-link to `cross-layer-orchestrator.md` Step 3 as
+      modified by ADR-K2-004) ; relationship to Oracle (brainstorm vs tune) ;
+      relationship to Demeter (disjoint surfaces) ; relationship to Vulcan/Hera
+      (advise vs implement). Reference all three b7-standards by name (satisfies
+      `_test_b7p_011`). [Story: FR-K2-PYT-007 / ADR-K2-004]
+- [ ] **T-INT-003** : Add `## Anti-Hallucination Protocol` H2 — Article III.4
+      contract : emit `[NEEDS CLARIFICATION:]` and STOP when a tuning target is
+      unspecified (no eval set for `ef_search`, undeclared embedding model,
+      undeclared tier) ; never fabricate `ef_search` / chunk-size / recall@k.
+      [Story: FR-K2-PYT-008 / 121 / NFR (anti-halluc)]
+- [ ] **T-INT-004** : Add file footer with the audit cross-references per
+      FR-K2-PYT-011 (new-archetypes-plan §9 / §6.2 / §0.12 + ARCHITECTURE-TARGET
+      §9.2 + the 3 b7-standards). [Story: FR-K2-PYT-011]
+- [ ] **T-INT-005** : Run harness ; expect integration + anti-halluc +
+      standards-consumed L1 tests GREEN. [Story: FR-K2-PYT-007 / 008 / 003]
+
+**Phase 2 exit gate** : 11 L1 tests GREEN (`_test_b7p_001..011`). `verify.sh`
+aggregate unchanged. `constitution-linter.sh` OVERALL PASS.
+
+---
+
+## Phase 3 — K.2.b/c : Standards-index + Janus + CLAUDE.md integration
+
+Goal : additive `index.yml` triggers, Janus delta-edited (Dispatch Table + Step 3
+note + Quality Gates bullet), CLAUDE.md row added, negative guards pass. After
+this phase, the remaining 7 L1 tests flip GREEN (`_test_b7p_012..018`).
+
+### T-IDX — standards-index additive triggers (ADR-K2-005)
+
+- [ ] **T-IDX-001** : RED witness — convert `_test_b7p_012_index_triggers` +
+      `_test_b7p_013_no_new_standard`. [Story: FR-K2-PYT-080 / 081]
+- [ ] **T-IDX-002** : Edit `.forge/standards/index.yml` — extend the `triggers:`
+      arrays of `global/rag-patterns`, `global/llm-gateway`, `global/mcp-servers`
+      (the B.7.3 block) with the ratified persona-name keyword (e.g. `pythia` or
+      `delphi`) ; add `ef-search` + `embeddings-tuning` to `rag-patterns`. NO new
+      index entry, NO new standard file. [Story: FR-K2-PYT-080 / ADR-K2-005]
+- [ ] **T-IDX-003** : Run harness + `validate-standards-yaml.sh` ; expect index
+      triggers + no-new-standard L1 tests GREEN and J.7 still PASS.
+      [Story: FR-K2-PYT-080 / 081 / NFR-K2-PYT-004 / 005]
+
+### T-JAN — Janus delta edit (ADR-K2-004, Article IV.1)
+
+- [ ] **T-JAN-001** : RED witness — convert `_test_b7p_014_janus_dispatch_row` +
+      `_test_b7p_015_janus_step3_note`. [Story: FR-K2-PYT-082 / 083 / ADR-K2-004]
+- [ ] **T-JAN-002** : Edit `.claude/agents/cross-layer-orchestrator.md` Dispatch
+      Table — insert the `<Pythia-Name>` AI/RAG row AFTER the Demeter row (line
+      32) and BEFORE the closing `---` (line 34) per the verbatim block in
+      ADR-K2-004. Do NOT modify any other row ; do NOT touch the Step 9 narrative
+      or the Forbidden-archetypes catalogue (b7-9-janus-ai territory).
+      [Story: FR-K2-PYT-082 / ADR-K2-004 / NFR-K2-PYT-006]
+- [ ] **T-JAN-003** : Edit `### Step 3 — Parallel Design Dispatch` — append the
+      `ai-native-rag` Pythia AI-pipeline design-pass paragraph per ADR-K2-004.
+      Add a one-bullet "AI/RAG readiness gate" entry to the **Quality Gates** H2.
+      Leave Step 9 (Aegis + Demeter) UNCHANGED. [Story: FR-K2-PYT-083 / ADR-K2-004]
+- [ ] **T-JAN-004** [P] : Edit Janus **Constitution compliance** H2 — add one
+      bullet citing AI-First (Article XI.5 + IX.6) reviewed by `<Pythia-Name>` for
+      `ai-native-rag`. [Story: FR-K2-PYT-083 / ADR-K2-004]
+- [ ] **T-JAN-005** : Run harness ; expect 2 Janus L1 tests GREEN ; assert Step 9
+      Demeter narrative byte-unchanged (k3.test.sh `_test_k3_018` still GREEN).
+      [Story: FR-K2-PYT-082..083 / NFR-K2-PYT-005 / 006]
+
+### T-CLM — CLAUDE.md trigger row
+
+- [ ] **T-CLM-001** : RED witness — convert `_test_b7p_016_claude_md_trigger`.
+      [Story: FR-K2-PYT-084]
+- [ ] **T-CLM-002** : Edit repo `CLAUDE.md` agent-delegation table (lines ~61-71)
+      — insert a row routing AI/RAG tuning work to `<Pythia-Name>` (AI/RAG
+      Specialist), adjacent to the `AI features | Oracle` row. Exact row text per
+      the ratified name (ADR-K2-001). [Story: FR-K2-PYT-084]
+- [ ] **T-CLM-003** : Run harness ; expect CLAUDE.md L1 test GREEN.
+      [Story: FR-K2-PYT-084]
+
+### T-NSC — namespace + no-scanner guards
+
+- [ ] **T-NSC-001** : RED witness — convert `_test_b7p_017_no_namespace_collision`
+      + `_test_b7p_018_no_scanner`. [Story: FR-K2-PYT-086 / NFR-K2-PYT-002]
+- [ ] **T-NSC-002** : Verify (no edit needed if invariants hold) :
+      `grep -r "K2-RULE" .claude/agents/cross-layer-orchestrator.md
+      .forge/standards/global/janus-orchestration-rules.md
+      .claude/agents/demeter.md` returns empty (the J8/K3 surfaces never reference
+      K2-RULE) AND `grep -rE "J8-RULE|K3-RULE" <PYTHIA_AGENT>` returns empty
+      except as cross-link acknowledgement ; AND no `bin/forge-pythia*.sh` /
+      `.forge/data/pythia*.yml` exist. [Story: FR-K2-PYT-086 / NFR-K2-PYT-002 /
+      ADR-K2-003]
+- [ ] **T-NSC-003** : Run harness `--level 1,2` ; expect ALL 19 tests (18 L1 + 1
+      L2) GREEN. [Story: FR-K2-PYT-086 / 101 / NFR-K2-PYT-007]
+
+### T-L2 — L2 fixture
+
+- [ ] **T-L2-001** : RED witness — convert `_test_b7p_l2_anchor_integrity`.
+      [Story: NFR-K2-PYT-007]
+- [ ] **T-L2-002** : Implement the L2 fixture — copy `$PYTHIA_AGENT` into a
+      tmpdir, re-run the L1 anchor greps (H2/H3 + K2-RULE-001..006) against the
+      isolated copy ; assert all present (proves the persona is self-contained,
+      no scanner needed). [Story: NFR-K2-PYT-007 / ADR-K2-003]
+- [ ] **T-L2-003** : Run harness `--level 1,2` ; expect 19/19 GREEN ≤ 5 s.
+      [Story: NFR-K2-PYT-007]
+
+**Phase 3 exit gate** : `b7-pythia.test.sh --level 1,2` 19/19 GREEN (18 L1 + 1
+L2). `verify.sh` aggregate unchanged or +1. `constitution-linter.sh` OVERALL
+PASS. `validate-standards-yaml.sh` / `j7` / `j8` / `k3` GREEN (no regression).
+
+---
+
+## Phase 4 — Quality : docs + CHANGELOG + open-questions flip + review
+
+### T-OQ — open-questions flip
+
+- [ ] **T-OQ-001** : Edit `open-questions.md` to flip Q-002 + Q-003 from
+      `Status: open` to `Status: answered` with `### Resolution` blocks citing
+      ADR-K2-002 / ADR-K2-003. **Q-001 stays `open` (BLOCKING) until the
+      maintainer ratifies ADR-K2-001 (T-Q01-002)** — the archival gate checks
+      Q-001 is `answered`, so this change cannot archive until ratification.
+      [Story: Article III.4]
+
+### T-DOC — documentation
+
+- [ ] **T-DOC-001** [P] : Add an agent-catalogue entry for `<Pythia-Name>` (AI/RAG
+      Specialist) to the agents doc located at impl time (likely a section in
+      `docs/` or the `forge-master.md` roster — locked at impl). Summarise
+      persona + 4 responsibilities + Janus Step 3 dispatch. [Story: FR-K2-PYT-007]
+- [ ] **T-DOC-002** [P] : Add a `## [Unreleased]` entry in `CHANGELOG.md`
+      covering the K.2 Pythia/`<Pythia-Name>` AI/RAG specialist (persona + Janus
+      delta + standards-index triggers + harness). Note the Q-001 rename if
+      Option A was chosen. [Story: FR-K2-PYT (docs)]
+- [ ] **T-DOC-003** [P] : Resync `docs/new-archetypes-plan.md` §0.12 brick table
+      line 2022 (brick #4 ⏳ pending → ✅ archived) + §9 K.2 row status. (Separate
+      maintainer resync task per the b7-2-scaffolder NFR-B7-2-001 precedent —
+      committed separately if the repo convention requires.) [Story: audit trail]
+
+### T-REV — quality review gate
+
+- [ ] **T-REV-001** : Run `/forge:review b7-pythia` driving the constitutional
+      gate : Articles I (TDD), III + III.4 (Q-001 BLOCKING check), IV (delta), V
+      (audit trail), IX.6 (prompt audit enforced), XI.1/3/5/6 (AI-First
+      enforced), XII (governance — no new standard, no amendment). Block if any
+      returns VIOLATION. [Story: Article V]
+- [ ] **T-REV-002** : Run full `verify.sh` + all sibling harnesses (`j7` / `j8` /
+      `k3` / `b7-1` / `b7-2a` / `b7-3` / `b7-2`) on a clean checkout ; confirm no
+      regression (NFR-K2-PYT-005). [Story: NFR-K2-PYT-005]
+- [ ] **T-REV-003** : Verify `bin/forge-questions.sh --change b7-pythia --status
+      open` returns ONLY Q-001 (BLOCKING) until maintainer ratification ; empty
+      after T-Q01-002. The change MUST NOT archive while Q-001 is open.
+      [Story: Article III.4]
+- [ ] **T-REV-004** : Smoke the 3 BDD scenarios from specs.md as a manual reviewer
+      read-through of the persona (dispatch wiring / K2-RULE-006 Blocking gate /
+      `ef_search` NEEDS-CLARIFICATION) — no executable to run (advisory agent).
+      [Story: Article II]
+- [ ] **T-REV-005** : Confirm the Janus Step 3 note + Dispatch Table row read
+      cleanly and the Step 9 Demeter narrative + Forbidden-archetypes catalogue
+      are untouched (collision guard vs b7-9-janus-ai). [Story: NFR-K2-PYT-006]
+
+**Phase 4 exit gate (= change archival readiness)** :
+
+- `b7-pythia.test.sh --level 1,2` 19/19 PASS / 0 FAIL / ≤ 5 s.
+- `verify.sh` aggregate ≥ baseline / RESULT: PASS.
+- `constitution-linter.sh` OVERALL PASS (no new WARN).
+- `j7` / `j8` / `k3` / `b7-1` / `b7-2a` / `b7-3` / `b7-2` unchanged.
+- `validate-standards-yaml.sh` exits 0 (index.yml edit is additive ; no new
+  standard).
+- **Q-001 ratified by the maintainer + flipped to `answered`** (BLOCKING — the
+  change cannot archive otherwise) ; Q-002 + Q-003 `answered`.
+- All FR-K2-PYT-001..125 + NFR-K2-PYT-001..007 tasks checked.
+- `CHANGELOG.md` `## [Unreleased]` entry.
+
+---
+
+## Constitutional task review (per Article V)
+
+| Task family | TDD order                                  | Spec link                       | Architecture                   |
+|-------------|--------------------------------------------|---------------------------------|--------------------------------|
+| T-PHA-*     | RED phase (intentional)                    | FR-K2-PYT-001..086              | name-agnostic harness          |
+| T-Q01-*     | BLOCKING gate (maintainer ratification)    | FR-K2-PYT-001 / Article III.4   | ADR-K2-001                     |
+| T-PER-*     | RED witness then persona skeleton          | FR-K2-PYT-001..003 / 010        | ADR-K2-001                     |
+| T-CHK-*     | RED witness then 4 checklist H3            | FR-K2-PYT-004 / 020..027        | Aegis/Demeter pattern          |
+| T-OUT-*     | RED witness then report H2                 | FR-K2-PYT-005                   | Demeter report template (advisory) |
+| T-CAT-*     | RED witness then rule table                | FR-K2-PYT-006 / 120..125        | ADR-K2-002                     |
+| T-INT-*     | RED witness then integration + anti-halluc | FR-K2-PYT-007..008 / 011 / 003  | ADR-K2-004                     |
+| T-IDX-*     | RED witness then additive triggers         | FR-K2-PYT-080..081              | ADR-K2-005 (NO new standard)   |
+| T-JAN-*     | RED witness then Janus delta-edit          | FR-K2-PYT-082..083              | ADR-K2-004 + Article IV.1      |
+| T-CLM-*     | RED witness then CLAUDE.md row             | FR-K2-PYT-084                   | Forge agent dispatch convention|
+| T-NSC-*     | RED witness then verify (guards)           | FR-K2-PYT-086 / NFR-K2-PYT-002  | ADR-K2-003 (no scanner)        |
+| T-L2-*      | RED witness then anchor-integrity fixture  | NFR-K2-PYT-007                  | ADR-K2-003 (no scanner L2)     |
+| T-OQ-*      | Open-questions flip (Q-001 stays BLOCKING) | Article III.4                   | k3-demeter precedent           |
+| T-DOC-*     | No code, doc-only                          | FR-K2-PYT (docs)                | CHANGELOG + plan-resync conventions |
+| T-REV-*     | Final gate, no production code             | Article V / II / III.4          | All articles                   |
+
+No `[TASK VIOLATION]` detected. Plan proceeds to `/forge:implement` **after Q-001
+ratification (T-Q01)**.
+
+---
+
+## Task counts by phase
+
+| Phase | Tasks | Parallelizable `[P]` | RED witnesses |
+|-------|-------|----------------------|---------------|
+| 1     | 5     | 2                    | 19 stubs      |
+| 0.5   | 2     | 0                    | 0 (gate)      |
+| 2     | 16    | 0                    | 11 (per cluster) |
+| 3     | 14    | 1                    | 8 (per cluster) |
+| 4     | 9     | 4                    | 0 (validation only) |
+| **Total** | **46** | **7** | **38 RED witnesses** |
+
+Estimated wall-clock at single-developer pace : Phase 1 ≈ 1 h, Q-001 gate ≈
+maintainer-latency-bound, Phase 2 ≈ 3–4 h, Phase 3 ≈ 2–3 h, Phase 4 ≈ 1 h. Total
+≈ 1.5–2 working days (smaller than k3-demeter's 2–2.5 days because there is no
+scanner / Python engine / data file), consistent with the **M** complexity
+estimate in `proposal.md` (`new-archetypes-plan` §9 row K.2 effort = `M`).

--- a/.forge/scripts/tests/b7-pythia.test.sh
+++ b/.forge/scripts/tests/b7-pythia.test.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# Forge — K.2 Sibyl (AI/RAG Specialist) Test Harness (b7-pythia)
+# <!-- Audit: K.2 (b7-pythia) -->
+# <!-- Audit: B.7.4 (b7-pythia) -->
+#
+# Validates the K.2 deliverables across 3 sub-modules :
+#
+#   K.2.a — Sibyl persona file
+#     - .claude/agents/sibyl.md (persona, checklists, output, rules,
+#       integration, anti-hallucination, audit cross-references)
+#
+#   K.2.b — Standards-index additive triggers (NO new standard)
+#     - .forge/standards/index.yml (rag-patterns / llm-gateway / mcp-servers
+#       triggers extended with the Sibyl keyword — no new entry, no new file)
+#
+#   K.2.c — Janus + CLAUDE.md integration
+#     - .claude/agents/cross-layer-orchestrator.md (Dispatch Table row +
+#       Step 3 ai-native-rag note + Quality Gates bullet — delta, ADR-K2-004)
+#     - CLAUDE.md trigger row
+#
+# DIVERGENCE FROM THE k3-demeter PRECEDENT (ADR-K2-003) : Sibyl is a pure
+# advisory / tuning specialist. This brick ships NO scanner (`bin/forge-*.sh`),
+# NO data file (`.forge/data/*.yml`), NO new standard. The negative guards
+# `_test_b7p_013_no_new_standard` + `_test_b7p_018_no_scanner` assert this.
+#
+# Name-resolution (NFR-K2-PYT-007) : the agent path is resolved from a single
+# `PYTHIA_AGENT` variable (default `.claude/agents/sibyl.md`, the ADR-K2-001
+# ratified path — Q-001 resolved to "Sibyl"), overridable by env, so the suite
+# asserts file + anchors, not the literal name.
+#
+# 19 tests : 18 L1 hermetic + 1 L2 fixture-based.
+# Performance : L1 ≤ 3 s (pure grep), full ≤ 5 s wall-clock (no Python, no cargo).
+
+set -uo pipefail
+
+LEVEL="1"
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--level" ]; then LEVEL="$arg"; fi
+  case "$arg" in --level=*) LEVEL="${arg#*=}" ;; esac
+  prev="$arg"
+done
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$HARNESS_DIR/.." && pwd)"
+FORGE_ROOT_REAL="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+# NFR-K2-PYT-007 — single name-resolution variable (ADR-K2-001 → "Sibyl").
+PYTHIA_AGENT="${PYTHIA_AGENT:-$FORGE_ROOT_REAL/.claude/agents/sibyl.md}"
+JANUS_AGENT="$FORGE_ROOT_REAL/.claude/agents/cross-layer-orchestrator.md"
+JANUS_RULES_STD="$FORGE_ROOT_REAL/.forge/standards/global/janus-orchestration-rules.md"
+DEMETER_AGENT="$FORGE_ROOT_REAL/.claude/agents/demeter.md"
+STANDARDS_INDEX="$FORGE_ROOT_REAL/.forge/standards/index.yml"
+STANDARDS_GLOBAL_DIR="$FORGE_ROOT_REAL/.forge/standards/global"
+REPO_CLAUDE_MD="$FORGE_ROOT_REAL/CLAUDE.md"
+
+# shellcheck source=./_helpers.sh
+source "$HARNESS_DIR/_helpers.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+# ─── Manifest ────────────────────────────────────────────────────
+#
+# L1 (18 tests)
+# MANIFEST: _test_b7p_001_persona_exists          — FR-K2-PYT-001 file presence
+# MANIFEST: _test_b7p_002_audit_comment           — FR-K2-PYT-010 audit comments (K.2 + B.7.4)
+# MANIFEST: _test_b7p_003_persona_h2              — FR-K2-PYT-002/003 Persona + Purpose H2
+# MANIFEST: _test_b7p_004_checklists_h2           — FR-K2-PYT-004 Checklists H2 + 4 H3
+# MANIFEST: _test_b7p_005_checklists_items        — FR-K2-PYT-004 ≥ 5 [ ] items per H3
+# MANIFEST: _test_b7p_006_output_h2               — FR-K2-PYT-005 Output: RAG Readiness Report
+# MANIFEST: _test_b7p_007_rule_catalogue          — FR-K2-PYT-006/120..125 K2-RULE-001..006
+# MANIFEST: _test_b7p_008_fallback_blocking       — FR-K2-PYT-125 K2-RULE-006 Blocking + XI.5
+# MANIFEST: _test_b7p_009_integration             — FR-K2-PYT-007 Integration H2 + Janus/Oracle/Demeter
+# MANIFEST: _test_b7p_010_anti_halluc             — FR-K2-PYT-008 Anti-Hallucination Protocol
+# MANIFEST: _test_b7p_011_standards_consumed      — FR-K2-PYT-003/020..027 three b7-standards referenced
+# MANIFEST: _test_b7p_012_index_triggers          — FR-K2-PYT-080 index.yml triggers extended
+# MANIFEST: _test_b7p_013_no_new_standard         — FR-K2-PYT-081 no new global/*.md standard
+# MANIFEST: _test_b7p_014_janus_dispatch_row      — FR-K2-PYT-082 Janus dispatch row
+# MANIFEST: _test_b7p_015_janus_step3_note        — FR-K2-PYT-083 Step 3 note + Step 9 UNCHANGED guard
+# MANIFEST: _test_b7p_016_claude_md_trigger       — FR-K2-PYT-084 CLAUDE.md trigger row
+# MANIFEST: _test_b7p_017_no_namespace_collision  — FR-K2-PYT-086 K2-RULE / J8-RULE / K3-RULE separation
+# MANIFEST: _test_b7p_018_no_scanner              — NFR-K2-PYT-002 / ADR-K2-003 no scanner / data file
+#
+# L2 (1 fixture test)
+# MANIFEST: _test_b7p_l2_anchor_integrity   — NFR-K2-PYT-007 fresh-checkout anchor integrity
+
+# ─── Helpers ────────────────────────────────────────────────────
+
+_setup_l2() {
+  L2_TMP="$(mk_tmpdir_with_trap forge-b7p-l2)"
+}
+
+_teardown_l2() {
+  if [ -n "${L2_TMP:-}" ] && [ -d "$L2_TMP" ]; then
+    rm -rf "$L2_TMP"
+  fi
+}
+
+_not_implemented() {
+  echo "    not implemented (RED witness — pending implementation tasks)" >&2
+  return 1
+}
+
+# ─── L1 stubs ───────────────────────────────────────────────────
+
+# FR-K2-PYT-001 Sibyl persona file exists
+_test_b7p_001_persona_exists() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-010 audit comments (K.2 + B.7.4) in first 6 lines
+_test_b7p_002_audit_comment() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! head -6 "$PYTHIA_AGENT" | grep -q "<!-- Audit: K.2 (b7-pythia) -->"; then
+    echo "    audit comment '<!-- Audit: K.2 (b7-pythia) -->' missing in first 6 lines" >&2; return 1
+  fi
+  if ! head -6 "$PYTHIA_AGENT" | grep -q "<!-- Audit: B.7.4 (b7-pythia) -->"; then
+    echo "    audit comment '<!-- Audit: B.7.4 (b7-pythia) -->' missing in first 6 lines" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-002/003 ## Persona + ## Purpose H2 anchors
+_test_b7p_003_persona_h2() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Persona$" "$PYTHIA_AGENT"; then
+    echo "    ## Persona H2 missing in $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Purpose$" "$PYTHIA_AGENT"; then
+    echo "    ## Purpose H2 missing in $PYTHIA_AGENT" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-004 ## Checklists + 4 H3 sub-sections
+_test_b7p_004_checklists_h2() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Checklists$" "$PYTHIA_AGENT"; then
+    echo "    ## Checklists H2 missing in $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^### Embeddings & Retrieval$" "$PYTHIA_AGENT"; then
+    echo "    ### Embeddings & Retrieval H3 missing" >&2; return 1
+  fi
+  if ! grep -q "^### pgvector HNSW Tuning$" "$PYTHIA_AGENT"; then
+    echo "    ### pgvector HNSW Tuning H3 missing" >&2; return 1
+  fi
+  if ! grep -q "^### MCP Server Hardening$" "$PYTHIA_AGENT"; then
+    echo "    ### MCP Server Hardening H3 missing" >&2; return 1
+  fi
+  if ! grep -q "^### Prompt Audit & Fallback$" "$PYTHIA_AGENT"; then
+    echo "    ### Prompt Audit & Fallback H3 missing" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-004 ≥ 5 [ ] items per checklist sub-section
+_test_b7p_005_checklists_items() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  for section in "Embeddings & Retrieval" "pgvector HNSW Tuning" "MCP Server Hardening" "Prompt Audit & Fallback"; do
+    local count
+    count="$(awk -v s="### $section" '
+      $0 == s {flag=1; next}
+      /^### / {flag=0}
+      flag && /\[ \]/ {n++}
+      END {print n+0}
+    ' "$PYTHIA_AGENT")"
+    if [ "$count" -lt 5 ]; then
+      echo "    H3 '$section' has only $count '[ ]' items (expected ≥ 5)" >&2; return 1
+    fi
+  done
+}
+
+# FR-K2-PYT-005 ## Output: RAG Readiness Report H2 + Summary table
+_test_b7p_006_output_h2() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Output: RAG Readiness Report$" "$PYTHIA_AGENT"; then
+    echo "    ## Output: RAG Readiness Report H2 missing" >&2; return 1
+  fi
+  if ! grep -q "| Severity |" "$PYTHIA_AGENT"; then
+    echo "    Severity summary table missing" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-006 / 120..125 ## Recommendation Catalogue + K2-RULE-001..006
+_test_b7p_007_rule_catalogue() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Recommendation Catalogue$" "$PYTHIA_AGENT"; then
+    echo "    ## Recommendation Catalogue H2 missing" >&2; return 1
+  fi
+  for rule in K2-RULE-001 K2-RULE-002 K2-RULE-003 K2-RULE-004 K2-RULE-005 K2-RULE-006; do
+    if ! grep -q "$rule" "$PYTHIA_AGENT"; then
+      echo "    $rule anchor missing in $PYTHIA_AGENT" >&2; return 1
+    fi
+  done
+}
+
+# FR-K2-PYT-125 K2-RULE-006 present + Blocking severity + XI.5 reference
+_test_b7p_008_fallback_blocking() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  # The K2-RULE-006 row must carry both 'Blocking' and an 'XI.5' reference.
+  if ! grep "K2-RULE-006" "$PYTHIA_AGENT" | grep -q "Blocking"; then
+    echo "    K2-RULE-006 not marked Blocking" >&2; return 1
+  fi
+  if ! grep "K2-RULE-006" "$PYTHIA_AGENT" | grep -q "XI.5"; then
+    echo "    K2-RULE-006 does not cite XI.5" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-007 ## Integration H2 + Janus / Oracle / Demeter mentions
+_test_b7p_009_integration() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Integration$" "$PYTHIA_AGENT"; then
+    echo "    ## Integration H2 missing" >&2; return 1
+  fi
+  if ! grep -q "cross-layer-orchestrator" "$PYTHIA_AGENT"; then
+    echo "    cross-layer-orchestrator reference missing" >&2; return 1
+  fi
+  if ! grep -q "Oracle" "$PYTHIA_AGENT"; then
+    echo "    Oracle relationship missing" >&2; return 1
+  fi
+  if ! grep -q "Demeter" "$PYTHIA_AGENT"; then
+    echo "    Demeter relationship missing" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-008 ## Anti-Hallucination Protocol H2 + [NEEDS CLARIFICATION:
+_test_b7p_010_anti_halluc() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  if ! grep -q "^## Anti-Hallucination Protocol$" "$PYTHIA_AGENT"; then
+    echo "    ## Anti-Hallucination Protocol H2 missing" >&2; return 1
+  fi
+  if ! grep -q "\[NEEDS CLARIFICATION:" "$PYTHIA_AGENT"; then
+    echo "    [NEEDS CLARIFICATION: marker mention missing" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-003 / 020..027 persona references all three b7-standards
+_test_b7p_011_standards_consumed() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  for std in "rag-patterns" "llm-gateway" "mcp-servers"; do
+    if ! grep -q "$std" "$PYTHIA_AGENT"; then
+      echo "    b7-standard reference missing: $std" >&2; return 1
+    fi
+  done
+}
+
+# FR-K2-PYT-080 index.yml rag-patterns/llm-gateway/mcp-servers triggers extended
+_test_b7p_012_index_triggers() {
+  if [ ! -f "$STANDARDS_INDEX" ]; then
+    echo "    standards index missing: $STANDARDS_INDEX" >&2; return 1
+  fi
+  # Each of the three B.7.3 entries must carry the 'sibyl' trigger keyword
+  # within its 5-line block.
+  for entry in "global/rag-patterns" "global/llm-gateway" "global/mcp-servers"; do
+    if ! grep -A 5 "id: $entry" "$STANDARDS_INDEX" | grep -q "sibyl"; then
+      echo "    'sibyl' trigger missing on $entry entry" >&2; return 1
+    fi
+  done
+  # rag-patterns also gains the ef-search + embeddings-tuning tuning keywords.
+  if ! grep -A 5 "id: global/rag-patterns" "$STANDARDS_INDEX" | grep -q "ef-search"; then
+    echo "    'ef-search' trigger missing on rag-patterns entry" >&2; return 1
+  fi
+  if ! grep -A 5 "id: global/rag-patterns" "$STANDARDS_INDEX" | grep -q "embeddings-tuning"; then
+    echo "    'embeddings-tuning' trigger missing on rag-patterns entry" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-081 no NEW global/*.md standard authored by this change
+_test_b7p_013_no_new_standard() {
+  # Sibyl owns the three pre-existing b7-standards by reference. This change
+  # MUST NOT author a new global/*.md standard (e.g. no rag-tuning-rules.md,
+  # no sibyl-rules.md, no ai-rag-*.md). Guard against task-creep toward K.3's
+  # data-stewardship-rules.md shape.
+  for forbidden in "$STANDARDS_GLOBAL_DIR/sibyl-rules.md" \
+                   "$STANDARDS_GLOBAL_DIR/pythia-rules.md" \
+                   "$STANDARDS_GLOBAL_DIR/rag-tuning-rules.md" \
+                   "$STANDARDS_GLOBAL_DIR/ai-rag-rules.md"; do
+    if [ -f "$forbidden" ]; then
+      echo "    forbidden new standard authored: $forbidden (ADR-K2-005 — additive triggers only)" >&2; return 1
+    fi
+  done
+  # The three b7-standards Sibyl consumes MUST exist (ownership by reference).
+  for std in rag-patterns llm-gateway mcp-servers; do
+    if [ ! -f "$STANDARDS_GLOBAL_DIR/$std.md" ]; then
+      echo "    expected pre-existing b7-standard missing: $std.md" >&2; return 1
+    fi
+  done
+}
+
+# FR-K2-PYT-082 Janus Dispatch Table contains the Sibyl AI/RAG row
+_test_b7p_014_janus_dispatch_row() {
+  if [ ! -f "$JANUS_AGENT" ]; then
+    echo "    janus agent missing: $JANUS_AGENT" >&2; return 1
+  fi
+  if ! grep -q "AI/RAG specialist work on" "$JANUS_AGENT"; then
+    echo "    Sibyl AI/RAG dispatch row missing in $JANUS_AGENT" >&2; return 1
+  fi
+  if ! grep -q "\*\*Sibyl\*\*" "$JANUS_AGENT"; then
+    echo "    Sibyl agent name not bolded in dispatch row" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-083 Step 3 ai-native-rag note + Step 9 Demeter narrative UNCHANGED
+_test_b7p_015_janus_step3_note() {
+  if [ ! -f "$JANUS_AGENT" ]; then
+    echo "    janus agent missing: $JANUS_AGENT" >&2; return 1
+  fi
+  # Step 3 H3 gains an ai-native-rag Sibyl design-pass note.
+  local step3_block
+  step3_block="$(awk '
+    /^### Step 3 — / {flag=1}
+    /^### Step 4 — / {flag=0}
+    flag {print}
+  ' "$JANUS_AGENT")"
+  if ! printf '%s' "$step3_block" | grep -q "ai-native-rag"; then
+    echo "    Step 3 ai-native-rag note missing" >&2; return 1
+  fi
+  if ! printf '%s' "$step3_block" | grep -q "Sibyl"; then
+    echo "    Step 3 Sibyl reference missing" >&2; return 1
+  fi
+  # COLLISION GUARD (NFR-K2-PYT-006) : the Step 9 Demeter narrative must be
+  # byte-unchanged — Sibyl never touches Step 9 (b7-9-janus-ai territory is the
+  # Forbidden catalogue ; Step 9 is Aegis + Demeter, owned by k3-demeter).
+  if ! grep -q "^### Step 9 — Security & Data-Stewardship Pass (Aegis + Demeter)$" "$JANUS_AGENT"; then
+    echo "    Step 9 Demeter narrative altered (must stay unchanged — collision guard)" >&2; return 1
+  fi
+  # Sibyl must NOT leak into the Step 9 block.
+  local step9_block
+  step9_block="$(awk '
+    /^### Step 9 — / {flag=1}
+    /^### Step 10 — / {flag=0}
+    flag {print}
+  ' "$JANUS_AGENT")"
+  if printf '%s' "$step9_block" | grep -q "Sibyl"; then
+    echo "    Sibyl leaked into Step 9 (must stay in Step 3 — collision guard)" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-084 repo CLAUDE.md trigger row contains the AI/RAG specialist
+_test_b7p_016_claude_md_trigger() {
+  if [ ! -f "$REPO_CLAUDE_MD" ]; then
+    echo "    repo CLAUDE.md missing: $REPO_CLAUDE_MD" >&2; return 1
+  fi
+  if ! grep -q "| AI/RAG tuning | \*\*Sibyl\*\* | AI/RAG Specialist |" "$REPO_CLAUDE_MD"; then
+    echo "    Sibyl AI/RAG trigger row missing in $REPO_CLAUDE_MD" >&2; return 1
+  fi
+}
+
+# FR-K2-PYT-086 K2-RULE never appears in J8/K3 surfaces (and vice-versa)
+_test_b7p_017_no_namespace_collision() {
+  # K2-RULE must NOT leak into the Janus agent file, the J.8 standard, or the
+  # Demeter persona (rule-body leakage check — disjoint namespaces).
+  if grep -q "K2-RULE" "$JANUS_AGENT" 2>/dev/null; then
+    echo "    K2-RULE leaked into $JANUS_AGENT" >&2; return 1
+  fi
+  if [ -f "$JANUS_RULES_STD" ] && grep -q "K2-RULE" "$JANUS_RULES_STD" 2>/dev/null; then
+    echo "    K2-RULE leaked into $JANUS_RULES_STD" >&2; return 1
+  fi
+  if [ -f "$DEMETER_AGENT" ] && grep -q "K2-RULE" "$DEMETER_AGENT" 2>/dev/null; then
+    echo "    K2-RULE leaked into $DEMETER_AGENT" >&2; return 1
+  fi
+  # J8-RULE / K3-RULE must NOT appear in the Sibyl persona except as a bounded
+  # cross-link acknowledgement (≤ 2 occurrences each).
+  if [ -f "$PYTHIA_AGENT" ]; then
+    local nj nk
+    nj="$(grep -c "J8-RULE" "$PYTHIA_AGENT" 2>/dev/null || echo 0)"
+    nk="$(grep -c "K3-RULE" "$PYTHIA_AGENT" 2>/dev/null || echo 0)"
+    if [ "$nj" -gt 2 ]; then
+      echo "    J8-RULE over-cited in $PYTHIA_AGENT ($nj hits, expected ≤ 2 cross-links)" >&2; return 1
+    fi
+    if [ "$nk" -gt 2 ]; then
+      echo "    K3-RULE over-cited in $PYTHIA_AGENT ($nk hits, expected ≤ 2 cross-links)" >&2; return 1
+    fi
+  fi
+}
+
+# NFR-K2-PYT-002 / ADR-K2-003 no scanner script + no data file (advisory-only)
+_test_b7p_018_no_scanner() {
+  # ADR-K2-003 : Sibyl is a pure advisory agent. No executable scanner, no
+  # data file. Guard against task-creep toward the k3-demeter scanner shape.
+  for s in "$FORGE_ROOT_REAL"/bin/forge-pythia*.sh "$FORGE_ROOT_REAL"/bin/forge-sibyl*.sh; do
+    if [ -e "$s" ]; then
+      echo "    forbidden scanner script present: $s (ADR-K2-003 — advisory only)" >&2; return 1
+    fi
+  done
+  for d in "$FORGE_ROOT_REAL"/.forge/data/pythia*.yml "$FORGE_ROOT_REAL"/.forge/data/sibyl*.yml; do
+    if [ -e "$d" ]; then
+      echo "    forbidden data file present: $d (ADR-K2-003 — advisory only)" >&2; return 1
+    fi
+  done
+}
+
+# ─── L2 stubs ───────────────────────────────────────────────────
+
+# NFR-K2-PYT-007 — copy $PYTHIA_AGENT into a tmpdir, re-run the L1 anchor greps
+# against the isolated copy (fresh-checkout simulation — proves the persona is
+# self-contained, no scanner needed).
+_test_b7p_l2_anchor_integrity() {
+  if [ ! -f "$PYTHIA_AGENT" ]; then
+    echo "    persona file missing: $PYTHIA_AGENT" >&2; return 1
+  fi
+  _setup_l2
+  trap '_teardown_l2' RETURN
+  local copy="$L2_TMP/sibyl.md"
+  cp "$PYTHIA_AGENT" "$copy"
+  # Re-run the structural anchor greps against the isolated copy — proves the
+  # persona is self-contained (no scanner, no repo-relative state needed).
+  for anchor in \
+    "^## Persona$" \
+    "^## Purpose$" \
+    "^## Checklists$" \
+    "^### Embeddings & Retrieval$" \
+    "^### pgvector HNSW Tuning$" \
+    "^### MCP Server Hardening$" \
+    "^### Prompt Audit & Fallback$" \
+    "^## Output: RAG Readiness Report$" \
+    "^## Recommendation Catalogue$" \
+    "^## Integration$" \
+    "^## Anti-Hallucination Protocol$"; do
+    if ! grep -q "$anchor" "$copy"; then
+      echo "    anchor '$anchor' missing on isolated copy" >&2; return 1
+    fi
+  done
+  for rule in K2-RULE-001 K2-RULE-002 K2-RULE-003 K2-RULE-004 K2-RULE-005 K2-RULE-006; do
+    if ! grep -q "$rule" "$copy"; then
+      echo "    rule '$rule' missing on isolated copy" >&2; return 1
+    fi
+  done
+}
+
+# ─── Main ────────────────────────────────────────────────────────
+
+main() {
+  echo "── K.2 — b7-pythia (Sibyl) harness (level $LEVEL) ──"
+  echo ""
+  echo "Phase 1: L1 — persona + index + Janus + integration anchors"
+  run_test _test_b7p_001_persona_exists
+  run_test _test_b7p_002_audit_comment
+  run_test _test_b7p_003_persona_h2
+  run_test _test_b7p_004_checklists_h2
+  run_test _test_b7p_005_checklists_items
+  run_test _test_b7p_006_output_h2
+  run_test _test_b7p_007_rule_catalogue
+  run_test _test_b7p_008_fallback_blocking
+  run_test _test_b7p_009_integration
+  run_test _test_b7p_010_anti_halluc
+  run_test _test_b7p_011_standards_consumed
+  run_test _test_b7p_012_index_triggers
+  run_test _test_b7p_013_no_new_standard
+  run_test _test_b7p_014_janus_dispatch_row
+  run_test _test_b7p_015_janus_step3_note
+  run_test _test_b7p_016_claude_md_trigger
+  run_test _test_b7p_017_no_namespace_collision
+  run_test _test_b7p_018_no_scanner
+
+  if [[ ",$LEVEL," == *",2,"* ]] || [[ "$LEVEL" == "1,2" ]] || [[ "$LEVEL" == "2" ]]; then
+    echo ""
+    echo "Phase 2: L2 — fresh-checkout anchor integrity"
+    run_test _test_b7p_l2_anchor_integrity
+  fi
+
+  print_summary
+}
+
+main "$@"

--- a/.forge/specs/ai-native-rag.md
+++ b/.forge/specs/ai-native-rag.md
@@ -308,3 +308,50 @@ Promotion candidate→stable/scaffoldable:true + ≥35-test promotion suite + sn
 tarball; `buf generate` + `cargo fetch` wiring (Qwik `rag_pb` import + Connect
 handler registration); Temporal activity contract (currently name-only markers);
 re-verify all 4 pins LIVE at promotion.
+
+---
+
+## ADDED Requirements (b7-pythia, archived 2026-06-22)
+
+K.2 / B.7.4 — the **Sibyl** AI/RAG specialist agent (advisory, NOT a scanner —
+ADR-K2-003). Namespace `FR-K2-PYT-*` / `NFR-K2-PYT-*` / `ADR-K2-*`. Persona name
+**Sibyl** ratified by the maintainer (ADR-K2-001 / Q-001 — the shipped
+Product-Analyst-Pythia is left untouched). Covered by
+`.forge/scripts/tests/b7-pythia.test.sh` (18 L1 + 1 L2, registered in `forge-ci.yml`).
+
+### Functional
+- **FR-K2-PYT-001..003 / 010** — persona `.claude/agents/sibyl.md` : audit comments, H1 `# Agent: AI/RAG Specialist (Sibyl)`, `## Persona`, `## Purpose` (cites K.2 + B.7.4 + the 3 b7-standards ; `ai-native-rag`-scoped).
+- **FR-K2-PYT-004 / 020..027** — `## Checklists` H2 with 4 H3 (Embeddings & Retrieval ; pgvector HNSW `ef_search` tuning ; MCP server hardening ; Prompt-audit IX.6 + mandatory fallback XI.5 + PII XI.6), each citing the consumed b7-standard.
+- **FR-K2-PYT-005** — `## Output: RAG Readiness Report` H2 (advisory, Demeter-shaped : Summary counts + Findings template + status line — BLOCKED only on the XI.5 gate / TUNING-NEEDED on any Concern / READY otherwise).
+- **FR-K2-PYT-006 / 120..125** — `## Recommendation Catalogue` H2 with `K2-RULE-001..006` (severity Advisory / Concern / Blocking ; K2-RULE-006 = Blocking, the XI.5 mandatory-fallback gate ; ADR-J8-004 numbering invariant, never reused).
+- **FR-K2-PYT-007** — `## Integration` H2 : Janus Step 3 dispatch for `ai-native-rag` ; relationships to Oracle (brainstorm vs tune), Demeter (disjoint surfaces), Vulcan/Hera (advise vs implement).
+- **FR-K2-PYT-008** — `## Anti-Hallucination Protocol` H2 (Article III.4) : emit `[NEEDS CLARIFICATION:]` + STOP on an unspecified tuning target ; never fabricate `ef_search` / chunk-size / recall@k.
+- **FR-K2-PYT-011** — file footer with the audit cross-references (plan §9 / §6.2 / §0.12 + ARCHITECTURE-TARGET §9.2 + the 3 b7-standards).
+- **FR-K2-PYT-080 / 081** — additive `triggers:` on the `global/{rag-patterns,llm-gateway,mcp-servers}` index entries (+ `ef-search` / `embeddings-tuning`) ; NO new standard, NO new index entry (ADR-K2-005).
+- **FR-K2-PYT-082 / 083** — Janus delta (ADR-K2-004, Article IV.1) : Dispatch Table row + Step 3 design-pass paragraph + Quality-Gates AI/RAG-readiness bullet + Constitution-compliance Article XI bullet — all in sections DISJOINT from `b7-9-janus-ai`.
+- **FR-K2-PYT-084** — repo `CLAUDE.md` agent-delegation row routing AI/RAG tuning to Sibyl.
+- **FR-K2-PYT-086** — namespace guard : no `K2-RULE` token leaks into the J8 / K3 surfaces ; no scanner script / data file.
+
+### Non-Functional
+- **NFR-K2-PYT-001** — additive only.
+- **NFR-K2-PYT-002** — NO scanner / data file / new standard (ADR-K2-003 ; guarded by `_test_b7p_013` + `_test_b7p_018`).
+- **NFR-K2-PYT-003** — Article V audit trail (`[Story: FR-K2-PYT-*]` task tags).
+- **NFR-K2-PYT-004** — J.7 standards-yaml GREEN (the `index.yml` edit is additive).
+- **NFR-K2-PYT-005** — no regression (`j7` / `j8` / `k3` / `b7-1` / `b7-2a` / `b7-2` / `b7-3` GREEN).
+- **NFR-K2-PYT-006** — collision guard (Step 9 Aegis+Demeter narrative + the J8-RULE Forbidden-archetypes catalogue byte-untouched).
+- **NFR-K2-PYT-007** — name-agnostic harness (single `PYTHIA_AGENT` var → `.claude/agents/sibyl.md`) + a fresh-checkout anchor-integrity L2 fixture.
+
+### ADRs (ratified — maintainer 2026-06-22; orchestrator independent verification GREEN)
+- **ADR-K2-001** — persona name **Sibyl** (Option B — name the new K.2 agent, keep Product-Analyst-Pythia ; supersedes the design's "Delphi" recommendation).
+- **ADR-K2-002** — incremental `K2-RULE` growth (6 seed rules ; mirrors ADR-K3-005).
+- **ADR-K2-003** — advisory agent : NO scanner / data file / new standard (Panoptes mould ; `ef_search`/embeddings tuning is workload-specific, not deterministically scannable).
+- **ADR-K2-004** — Janus integration by delta-edit (Article IV.1) in sections disjoint from `b7-9-janus-ai`.
+- **ADR-K2-005** — standards-index additive triggers only (Sibyl consumes the B.7.3 b7-standards ; no new standard file).
+
+### Open questions (resolved)
+- **Q-001** (name collision) → ADR-K2-001 (Sibyl). **Q-002** (rule count) → ADR-K2-002 (6, incremental). **Q-003** (scanner vs advisory) → ADR-K2-003 (advisory).
+
+### Downstream
+Janus dispatches Sibyl at Step 3 for `ai-native-rag` projects. The archetype's
+promotion to `scaffoldable: true` remains gated on a green `b7-6-harness`
+(unchanged by this brick).

--- a/.forge/standards/index.yml
+++ b/.forge/standards/index.yml
@@ -438,18 +438,18 @@ standards:
 
   - id: global/rag-patterns
     path: standards/global/rag-patterns.md
-    triggers: [rag, retrieval, embeddings, pgvector, hnsw, re-ranking, hybrid-search, vector-search, ai-native-rag, chunking, context-window]
+    triggers: [rag, retrieval, embeddings, pgvector, hnsw, re-ranking, hybrid-search, vector-search, ai-native-rag, chunking, context-window, ef-search, embeddings-tuning, sibyl]
     scope: all
     priority: high
 
   - id: global/llm-gateway
     path: standards/global/llm-gateway.md
-    triggers: [llm-gateway, llm, prompt-audit, token-budget, mistral, vllm, openai, byok, kill-switch, ai-native-rag, tier-aware]
+    triggers: [llm-gateway, llm, prompt-audit, token-budget, mistral, vllm, openai, byok, kill-switch, ai-native-rag, tier-aware, sibyl]
     scope: all
     priority: high
 
   - id: global/mcp-servers
     path: standards/global/mcp-servers.md
-    triggers: [mcp, rmcp, model-context-protocol, tool-router, stdio, streamable-http, mcp-oauth, ai-native-rag, sandboxing]
+    triggers: [mcp, rmcp, model-context-protocol, tool-router, stdio, streamable-http, mcp-oauth, ai-native-rag, sandboxing, sibyl]
     scope: all
     priority: high

--- a/.github/workflows/forge-ci.yml
+++ b/.github/workflows/forge-ci.yml
@@ -124,6 +124,7 @@ jobs:
             "b7-2a.test.sh --level 1,2"
             "b7-3.test.sh --level 1"
             "b7-2.test.sh --level 1"
+            "b7-pythia.test.sh --level 1,2"
           )
           fail=0
           for entry in "${harnesses[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ minor bump and will be called out under a `### BREAKING` subsection.
 
 ### Added
 
+- **K.2 AI/RAG specialist agent `Sibyl` (`b7-pythia`)** — a new advisory
+  `.claude/agents/sibyl.md` persona for the `ai-native-rag` archetype: four
+  checklists (Embeddings & Retrieval, pgvector HNSW Tuning, MCP Server Hardening,
+  Prompt Audit & Fallback) operationalising the three B.7.3 b7-standards
+  (`rag-patterns.md` / `llm-gateway.md` / `mcp-servers.md`) verbatim, a `RAG
+  Readiness Report` template, and a 6-rule recommendation catalogue
+  (`K2-RULE-001..006`) whose only `Blocking` rule is the Article XI.5
+  mandatory-fallback gate (`K2-RULE-006`). **Advisory only — NO scanner, NO data
+  file, NO new standard** (ADR-K2-003 divergence from the `k3-demeter` precedent;
+  HNSW/embeddings tuning is workload-specific and cannot be reduced to a
+  deterministic scan). Janus dispatches Sibyl at **Step 3** (design pass, not the
+  Step 9 security pass) for `ai-native-rag` projects: delta-edits to
+  `cross-layer-orchestrator.md` (Dispatch Table row + Step 3 note + Quality Gates
+  bullet + Constitution-compliance bullet, all disjoint from the J8-RULE
+  Forbidden-archetypes catalogue). `index.yml` triggers extended additively
+  (`sibyl` on rag-patterns/llm-gateway/mcp-servers + `ef-search` /
+  `embeddings-tuning` on rag-patterns — no new entry). CLAUDE.md + `forge-master.md`
+  roster gain an AI/RAG-Specialist row. The maintainer ratified the name **Sibyl**
+  (Q-001 Option B) — the shipped Product-Analyst-Pythia is untouched. Harness
+  `b7-pythia.test.sh` (18 L1 + 1 L2) in `forge-ci.yml`. Additive; no regression to
+  `j7` / `j8` / `k3` / `b7-1` / `b7-2a` / `b7-3` / `b7-2`.
+
 - **`ai-native-rag` pattern standards (B.7.3, `b7-standards`)** — three new
   `global/*.md` pattern standards the archetype schema references as
   `delivered_by: B.7.3`: `rag-patterns.md` (chunking/embeddings, hybrid retrieval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Forge uses specialized agents. Delegation is automatic:
 | Infrastructure | **Atlas** | Infra Architect |
 | Observability | **Panoptes** | Observability Specialist |
 | AI features | **Oracle** | AI-First Brainstorm |
+| AI/RAG tuning | **Sibyl** | AI/RAG Specialist |
 | Data stewardship | **Demeter** | Data Steward EU |
 | Writing specs | **Clio** | Spec Writer |
 | Domain modeling | **Socrates** | DDD Strategist |


### PR DESCRIPTION
## K.2 / B.7.4 — Sibyl, the AI/RAG specialist agent (b7-pythia)

Adds **Sibyl**, an **advisory** AI/RAG specialist agent for the `ai-native-rag` archetype — embeddings/retrieval tuning, pgvector HNSW `ef_search`, MCP server hardening, and prompt-audit + mandatory-fallback review. Brick #4 of the B.7 chain.

### Naming (Q-001)
The roadmap called the K.2 agent "Pythia", but that name is already the shipped **Product Analyst** (`product-analyst.md`). Maintainer ratified **Sibyl** for the new agent (ADR-K2-001, "Option B"); the existing Product-Analyst-Pythia and its references are **untouched**.

### What's in it
- **Persona** `.claude/agents/sibyl.md` (318 l.): Persona / Purpose / 4 Checklists / `RAG Readiness Report` output / `K2-RULE-001..006` catalogue (006 = Blocking, the Article XI.5 mandatory-fallback gate) / Anti-Hallucination Protocol.
- **Advisory, not a scanner** (ADR-K2-003): NO `bin/forge-*.sh`, NO data file, NO new standard — guarded by negative tests.
- **Janus delta** (`cross-layer-orchestrator.md`, +5 l.): Dispatch Table row + Step 3 design-pass paragraph + Quality-Gates bullet + Article XI compliance bullet — all in sections **disjoint** from `b7-9-janus-ai` (Step 9 / Demeter + the Forbidden-archetypes catalogue are byte-untouched).
- Additive `index.yml` triggers (rag-patterns / llm-gateway / mcp-servers + `ef-search`/`embeddings-tuning`), `CLAUDE.md` + `forge-master.md` roster rows, harness `b7-pythia.test.sh` (18 L1 + 1 L2, in CI), CHANGELOG.

### Verification (all GREEN)
`b7-pythia.test.sh` 19/19 · `verify.sh` PASS · `constitution-linter` PASS · `validate-standards-yaml` 8/0 · regression `k3 22/0` (incl. the Demeter Step-9 + namespace guards) · `j7 21/0 · j8 20/0 · b7-1 19/0 · b7-2a 4/0 · b7-2 7/0 · b7-3 7/0`. TDD RED (19/19 fail) → GREEN per the change's `tasks.md`.

Spec consolidated into `.forge/specs/ai-native-rag.md` (appended K.2 block; prior B.7 blocks preserved); change archived (`status: archived`, 2026-06-22). The archetype's promotion to `scaffoldable: true` remains gated on `b7-6-harness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPnqp5voa9PfC5JJ6HCKQz
